### PR TITLE
Ensure consistent formatting with EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+
+[*.{adoc,html,js,json,rb,yml}]
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[{Makefile,makefile,**.mk}]
+indent_style = tab
+indent_size = 8

--- a/Makefile
+++ b/Makefile
@@ -52,18 +52,18 @@ tc211-termbase.yaml tc211-termbase.meta.yaml concepts_data: tc211-termbase.xlsx
 _concepts: concepts_data
 	mkdir -p $@
 	for filename in $</*.yaml; do \
-	    [ -e "$$filename" ] || continue; \
+		[ -e "$$filename" ] || continue; \
 			newpath=$${filename//$<\/concept-/$@\/}; \
-	    cp $$filename $${newpath//yaml/adoc}; \
+		cp $$filename $${newpath//yaml/adoc}; \
 			echo "---" >> $${newpath//yaml/adoc}; \
 	done
 
 # index.xml: csd.rxl external.rxl admin.rxl
 # 	cp -a external/*.rxl csd/; \
 # 	bundle exec relaton concatenate \
-# 	  -t $(CSD_REGISTRY_NAME) \
+# 		-t $(CSD_REGISTRY_NAME) \
 # 		-g $(NAME_ORG) \
-# 	  csd/ $@
+# 		csd/ $@
 
 serve:
 	bundle exec jekyll serve


### PR DESCRIPTION
Use two spaces for indentation, trim trailing spaces, etc. See http://editorconfig.org/ for details.