### PR TITLE
Set page title explicitly

### DIFF
--- a/_pages/index.adoc
+++ b/_pages/index.adoc
@@ -2,6 +2,7 @@
 layout: custom-home
 permalink: /
 nav_items: [about, posts, stats, feedback, registers]
+title: Index
 ---
 :page-liquid:
 


### PR DESCRIPTION
The appearance of the `index.html` page (`<title>` element, specifically) has changed slightly due to some internal changes.  Providing page title explicitly in the front matter fixes this issue, and matches the appearance to the old geolexica.org site.