### PR TITLE
Introduce "geolexica" entries group in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,8 +51,9 @@ collections:
     output: true
     output_ext: .ttl
 
-term_languages:
-  - eng
+geolexica:
+  term_languages:
+    - eng
 
 exclude:
   - spec/

--- a/_layouts/concept.html
+++ b/_layouts/concept.html
@@ -44,7 +44,7 @@ term_attributes:
   </p>
 </section>
 
-{% for lang in site.term_languages %}
+{% for lang in site.geolexica.term_languages %}
   {% assign localized_term = page[lang] %}
 
   {% if localized_term %}

--- a/_layouts/concept.json.html
+++ b/_layouts/concept.json.html
@@ -4,7 +4,7 @@ layout: null
 {
   "term": "{{ page.term }}",
   "termid": {{ page.termid }},
-  {%- for lang in site.term_languages -%}
+  {%- for lang in site.geolexica.term_languages -%}
   {% assign localized_term = page[lang] %}
   "{{ lang }}": {{ localized_term | jsonify }}{% unless forloop.last %},{% endunless %}
   {% endfor %}

--- a/_layouts/concept.jsonld.html
+++ b/_layouts/concept.jsonld.html
@@ -18,7 +18,7 @@ layout: null
   "skos:notation": "{{ page.termid }}",
 
   "skos:prefLabel": [
-    {%- for lang in site.term_languages -%}
+    {%- for lang in site.geolexica.term_languages -%}
     {%- assign localized_term = page[lang] -%}
     {%- if localized_term.term -%}
     {
@@ -30,7 +30,7 @@ layout: null
   ],
 
   "skos:altLabel": [
-    {%- for lang in site.term_languages -%}
+    {%- for lang in site.geolexica.term_languages -%}
     {%- assign localized_term = page[lang] -%}
     {%- if localized_term.alt -%}
     {
@@ -42,7 +42,7 @@ layout: null
   ],
 
   "skos:definition": [
-    {%- for lang in site.term_languages -%}
+    {%- for lang in site.geolexica.term_languages -%}
     {%- assign localized_term = page[lang] -%}
     {%- if localized_term.definition -%}
     {
@@ -63,7 +63,7 @@ layout: null
 
   {%- if concept.notes -%}
   "notes": {
-    {%- for lang in site.term_languages -%}
+    {%- for lang in site.geolexica.term_languages -%}
     {%- assign localized_term = page[lang] -%}
     {%- if localized_term.notes.size > 0 -%}
     "{{ lang }}": [
@@ -93,7 +93,7 @@ layout: null
 
   {%- if concept.examples -%}
   "examples": {
-    {%- for lang in site.term_languages -%}
+    {%- for lang in site.geolexica.term_languages -%}
     {%- assign localized_term = page[lang] -%}
     {%- if localized_term.examples.size > 0 -%}
     "{{ lang }}": [

--- a/_layouts/concept.ttl.html
+++ b/_layouts/concept.ttl.html
@@ -33,7 +33,7 @@ layout: null
   dcterms:source "{{ concept.authoritative_source.link }}" ;
 {%- endif %}
 
-{%- for lang in site.term_languages %}
+{%- for lang in site.geolexica.term_languages %}
 {%- assign localized_term = page[lang] -%}
 {%- if localized_term.term %}
   rdf-profile:{{ lang }}Origin rdf-profile:{{ site.data.lang[lang].lang_en }} ;
@@ -42,7 +42,7 @@ layout: null
   rdf-profile:termID <{{ page.url }}> ;
   rdfs:label "{{ english.term | escape }}" ;
   skos:notation {{ page.termid }} ;
-{%- for lang in site.term_languages %}
+{%- for lang in site.geolexica.term_languages %}
 {%- assign localized_term = page[lang] -%}
 {%- if localized_term.definition %}
   skos:definition "{{ localized_term.definition | escape }}"@{{ site.data.lang[lang].iso-639-1 }} ;
@@ -50,14 +50,14 @@ layout: null
 {%- endfor %}
   skos:inScheme rdf-profile:GeolexicaConceptScheme ;
 
-{%- for lang in site.term_languages %}
+{%- for lang in site.geolexica.term_languages %}
 {%- assign localized_term = page[lang] -%}
 {%- if localized_term.term %}
   skos:prefLabel "{{ localized_term.term | escape }}"@{{ site.data.lang[lang].iso-639-1 }} ;
 {%- endif %}
 {%- endfor %}
 
-{%- for lang in site.term_languages %}
+{%- for lang in site.geolexica.term_languages %}
 {%- assign localized_term = page[lang] -%}
 {%- if localized_term.alt %}
   skos:altLabel "{{ localized_term.alt | escape }}"@{{ site.data.lang[lang].iso-639-1 }} ;

--- a/_pages/concepts-index-list.json
+++ b/_pages/concepts-index-list.json
@@ -8,7 +8,7 @@ permalink: "/api/concepts-index-list.json"
     "term": {{ concept.term | jsonify }},
 
     {% assign english_concept = concept["eng"] %}
-    {% for lang in site.term_languages %}
+    {% for lang in site.geolexica.term_languages %}
 
     "{{ lang }}": {% if concept[lang] %}{
       "term": {{ concept[lang].term | jsonify }},

--- a/_pages/stats.json
+++ b/_pages/stats.json
@@ -3,7 +3,7 @@ permalink: "/api/stats.json"
 layout: null
 ---
 {
-  {% for lang in site.term_languages %}
+  {% for lang in site.geolexica.term_languages %}
   {%- assign counter = 0 -%}
   {%- for concept in site.concepts -%}
     {% unless concept[lang] == nil or concept[lang] == "" %}


### PR DESCRIPTION
Aggregate all the glossary configuration under a `_config.yml` entry named `geolexica`. For now it's only a term languages list, but there will be more of that.