### PR TITLE
Make concepts path configurable

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -52,6 +52,7 @@ collections:
     output_ext: .ttl
 
 geolexica:
+  concepts_glob: "./geolexica-database/concepts/*.yaml"
   term_languages:
     - eng
 

--- a/lib/jekyll/geolexica/concepts_generator.rb
+++ b/lib/jekyll/geolexica/concepts_generator.rb
@@ -47,7 +47,8 @@ module Jekyll
       end
 
       def concepts_glob
-        File.expand_path("./geolexica-database/concepts/*.yaml", site.source)
+        glob_string = site.config.dig("geolexica", "concepts_glob")
+        File.expand_path(glob_string, site.source)
       end
 
       def add_page *pages


### PR DESCRIPTION
Geolexica for ISO/TC 211 keeps its concepts in `geolexica-database`, whereas OsGeo in `osgeo-glossary`. Now this path can be configured via `geolexica` -> `concepts_glob` option in `_config.yml`.