### PR TITLE
More customizable layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,7 +24,7 @@
                 ISO
               </span>
               <span class="widget-item committee-id">
-                TC {{ site.committee.id }}
+                TC {{ site.committee.identifier }}
               </span>
               <span class="widget-item committee-name">
                 {{ site.committee.name }}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -108,7 +108,7 @@
     {% if site.awards and page.hide_awards != true %}
       <p class="awards">
         <i class="fa fa-certificate icon"></i>
-        Winner of 
+        Winner of
         {% for award in site.awards %}
           <span class="award">the <a href="{{ award.path }}"
             >{{ award.title }}</a>{%- unless forloop.last -%}, {% endunless %}</span>{% endfor %}.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,15 +20,21 @@
         <div class="site-title">
           <span class="committee-widget">
             <span class="widget-group">
+              {%- if site.committee.parent_org_name %}
               <span class="widget-item parent-org-reference">
                 {{ site.committee.parent_org_name }}
               </span>
+              {%- endif %}
+              {%- if site.committee.identifier %}
               <span class="widget-item committee-id">
                 {{ site.committee.identifier }}
               </span>
+              {%- endif %}
+              {%- if site.committee.name %}
               <span class="widget-item committee-name">
                 {{ site.committee.name }}
               </span>
+              {%- endif %}
 
               {% if page.layout == "home" and site.always_show_committee_link_on_landing and site.committee.home %}
                 <a href="{{ site.committee.home }}" class="widget-item home">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,7 +13,7 @@
       <div class="site-headline">
         <div class="parent-org-reference">
           <a href="/" class="logo-link">
-            <img src="{{ "/assets/logo-iso-noninverted.svg" | relative_url }}" alt="ISO">
+            <img src="{{ site.committee.main_logo.path | relative_url }}" alt="{{ site.committee.main_logo.alt_text }}">
           </a>
         </div>
 
@@ -21,10 +21,10 @@
           <span class="committee-widget">
             <span class="widget-group">
               <span class="widget-item parent-org-reference">
-                ISO
+                {{ site.committee.parent_org_name }}
               </span>
               <span class="widget-item committee-id">
-                TC {{ site.committee.identifier }}
+                {{ site.committee.identifier }}
               </span>
               <span class="widget-item committee-name">
                 {{ site.committee.name }}
@@ -142,7 +142,7 @@
       </p>
 
       <div class="logo">
-        <a href="https://www.iso.org/"><img src="{{ "/assets/logo-iso-noninverted.svg" | relative_url }}" alt="ISO organization"/></a>
+        <a href="{{ site.committee.footer_logo.url }}"><img src="{{ site.committee.footer_logo.path | relative_url }}" alt="{{ site.committee.footer_logo.alt_text }}"/></a>
       </div>
     </footer>
 


### PR DESCRIPTION
Make the layout more configurable, and suitable for larger number of projects.

This pull request adds a few more settings to `committee` entry in `_config.yml` file, which allow for customization of brand names and logos: `committee.parent_org_name`, `committee.main_logo`, `committee.footer_logo`. Also, `committee.id` is renamed to `committee.identifier`, and has a slightly different purpose. Finally, some of these fields are now displayed optionally.