### PR TITLE
Improve how Geolexica configuration is handled

### DIFF
--- a/lib/jekyll/geolexica.rb
+++ b/lib/jekyll/geolexica.rb
@@ -8,6 +8,7 @@ module Jekyll
   end
 end
 
+require_relative "geolexica/configuration"
 require_relative "geolexica/concept_page"
 require_relative "geolexica/concepts_generator"
 require_relative "geolexica/meta_pages_generator"

--- a/lib/jekyll/geolexica/concepts_generator.rb
+++ b/lib/jekyll/geolexica/concepts_generator.rb
@@ -4,6 +4,8 @@
 module Jekyll
   module Geolexica
     class ConceptsGenerator < Generator
+      include Configuration
+
       safe true
 
       attr_reader :generated_pages, :site
@@ -45,11 +47,6 @@ module Jekyll
         generated_pages.each do |page|
           site.collections[page.collection_name].docs.push(page)
         end
-      end
-
-      def concepts_glob
-        glob_string = site.config.dig("geolexica", "concepts_glob")
-        File.expand_path(glob_string, site.source)
       end
 
       def add_page *pages

--- a/lib/jekyll/geolexica/configuration.rb
+++ b/lib/jekyll/geolexica/configuration.rb
@@ -1,0 +1,14 @@
+# (c) Copyright 2020 Ribose Inc.
+#
+
+module Jekyll
+  module Geolexica
+    module Configuration
+      protected
+
+      def glossary_config
+        site.config["geolexica"] || {}
+      end
+    end
+  end
+end

--- a/lib/jekyll/geolexica/configuration.rb
+++ b/lib/jekyll/geolexica/configuration.rb
@@ -4,6 +4,11 @@
 module Jekyll
   module Geolexica
     module Configuration
+      def concepts_glob
+        glob_string = glossary_config["concepts_glob"]
+        File.expand_path(glob_string, site.source)
+      end
+
       protected
 
       def glossary_config

--- a/spec/unit/jekyll/geolexica/configuration_spec.rb
+++ b/spec/unit/jekyll/geolexica/configuration_spec.rb
@@ -1,0 +1,64 @@
+# (c) Copyright 2020 Ribose Inc.
+#
+
+RSpec.describe ::Jekyll::Geolexica::Configuration do
+  let(:described_module) { described_class }
+
+  let(:wrapper) do
+    wrapper = OpenStruct.new(site: fake_site)
+    wrapper.extend(described_module)
+    wrapper
+  end
+
+  let(:fake_site) do
+    instance_double(
+      Jekyll::Site,
+      config: fake_config,
+      source: fake_site_source,
+    )
+  end
+
+  let(:fake_config) { load_plugin_config }
+  let(:fake_site_source) { "/some/path" }
+  let(:fake_geolexica_config) { fake_config["geolexica"] }
+
+  describe "#glossary_config" do
+    subject { wrapper.method(:glossary_config) }
+
+    it "returns a Geolexica configuration" do
+      fake_geolexica_config.replace({some: "entries"})
+      expect(subject.()).to eq(fake_geolexica_config)
+    end
+
+    it "has some sensible defaults" do
+      expect(subject.()).to be_a(Hash)
+      expect(subject.()).not_to be_empty
+    end
+  end
+
+  describe "#concepts_glob" do
+    subject { wrapper.method(:concepts_glob) }
+
+    it "returns a configured glob path to concepts" do
+      fake_geolexica_config.replace({"concepts_glob" => "./some/glob/*"})
+      expect(subject.()).to eq("#{fake_site_source}/some/glob/*")
+    end
+
+    it "has some sensible defaults" do
+      expect(subject.()).to be_a(String) & match(/\*/)
+    end
+  end
+
+  describe "term languages" do
+    specify "are configurable in Geolexica, and have sensible defaults" do
+      langs = fake_geolexica_config["term_languages"]
+      expect(langs).to be_an(Array) & include("eng")
+    end
+  end
+
+  def load_plugin_config
+    path = File.expand_path("../../../../_config.yml", __dir__)
+    yaml = File.read(path)
+    YAML.load(yaml)
+  end
+end


### PR DESCRIPTION
- Introduce a `Configuration` module, which provides configuration accessors.
- Write specs which are missing so far.