### PR TITLE
Make supported output formats configurable

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -52,6 +52,8 @@ geolexica:
   concepts_glob: "./geolexica-database/concepts/*.yaml"
   term_languages:
     - eng
+  formats:
+    - html
 
 exclude:
   - spec/

--- a/_layouts/concept.html
+++ b/_layouts/concept.html
@@ -54,26 +54,32 @@ term_attributes:
 
 {% endfor %}
 
+{% if site.geolexica.formats contains 'json' -%}
 {% assign json_concept = site.concepts_json | where: 'termid', page.termid | first -%}
 {% assign json_url = json_concept.url -%}
 <section class="field json">
   <p class="field-name">JSON</p>
   <p class="field-value"><a href="{{ json_url }}">{{ json_url }}</a></p>
 </section>
+{%- endif %}
 
+{% if site.geolexica.formats contains 'json-ld' -%}
 {% assign json_concept = site.concepts_jsonld | where: 'termid', page.termid | first -%}
 {% assign json_url = json_concept.url -%}
 <section class="field json">
   <p class="field-name">SKOS in JSON-LD</p>
   <p class="field-value"><a href="{{ json_url }}">{{ json_url }}</a></p>
 </section>
+{%- endif %}
 
+{% if site.geolexica.formats contains 'turtle' -%}
 {% assign ttl_concept = site.concepts_ttl | where: 'termid', page.termid | first -%}
 {% assign ttl_url = ttl_concept.url -%}
 <section class="field ttl">
   <p class="field-name">SKOS in RDF</p>
   <p class="field-value"><a href="{{ ttl_url }}">{{ ttl_url }}</a></p>
 </section>
+{%- endif %}
 
 <section class="field info">
   <p class="field-name">info</p>

--- a/lib/jekyll/geolexica/concepts_generator.rb
+++ b/lib/jekyll/geolexica/concepts_generator.rb
@@ -32,10 +32,10 @@ module Jekyll
             "processing concept data #{concept_file_path}")
           concept_hash = read_concept_file(concept_file_path)
           preprocess_concept_hash(concept_hash)
-          add_page ConceptPage::HTML.new(site, concept_hash)
-          add_page ConceptPage::JSON.new(site, concept_hash)
-          add_page ConceptPage::JSONLD.new(site, concept_hash)
-          add_page ConceptPage::Turtle.new(site, concept_hash)
+          add_page ConceptPage::HTML.new(site, concept_hash) if output_html?
+          add_page ConceptPage::JSON.new(site, concept_hash) if output_json?
+          add_page ConceptPage::JSONLD.new(site, concept_hash) if output_jsonld?
+          add_page ConceptPage::Turtle.new(site, concept_hash) if output_turtle?
         end
       end
 

--- a/lib/jekyll/geolexica/configuration.rb
+++ b/lib/jekyll/geolexica/configuration.rb
@@ -9,6 +9,22 @@ module Jekyll
         File.expand_path(glob_string, site.source)
       end
 
+      def output_html?
+        glossary_config["formats"].include?("html")
+      end
+
+      def output_json?
+        glossary_config["formats"].include?("json")
+      end
+
+      def output_jsonld?
+        glossary_config["formats"].include?("json-ld")
+      end
+
+      def output_turtle?
+        glossary_config["formats"].include?("turtle")
+      end
+
       protected
 
       def glossary_config

--- a/lib/jekyll/geolexica/meta_pages_generator.rb
+++ b/lib/jekyll/geolexica/meta_pages_generator.rb
@@ -4,6 +4,8 @@
 module Jekyll
   module Geolexica
     class MetaPagesGenerator < Generator
+      include Configuration
+
       safe true
 
       attr_reader :generated_pages, :site
@@ -25,6 +27,7 @@ module Jekyll
       # Processes concepts and yields a bunch of Jekyll::Page instances.
       def make_pages
         all_pages_pathnames.each do |p|
+          next if skip_page?(p)
           add_page Page.new(site, base_dir, p.dirname.to_s, p.basename.to_s)
         end
       end
@@ -39,6 +42,12 @@ module Jekyll
 
       def base_dir
         File.expand_path("../../../_pages", __dir__)
+      end
+
+      def skip_page?(pathname)
+        (pathname.extname == ".ttl" && !output_turtle?) ||
+        (pathname.extname == ".json" && !output_json?) ||
+        false
       end
 
       def add_page *pages

--- a/spec/unit/jekyll/geolexica/configuration_spec.rb
+++ b/spec/unit/jekyll/geolexica/configuration_spec.rb
@@ -56,6 +56,38 @@ RSpec.describe ::Jekyll::Geolexica::Configuration do
     end
   end
 
+  describe "output formats" do
+    specify "are configurable in Geolexica, and have sensible defaults" do
+      formats = fake_geolexica_config["formats"]
+      expect(formats).to be_an(Array) & include("html")
+    end
+
+    specify "settings are accessible via convenience methods" do
+      expect(wrapper).to respond_to(:output_html?)
+      expect(wrapper).to respond_to(:output_json?)
+      expect(wrapper).to respond_to(:output_jsonld?)
+      expect(wrapper).to respond_to(:output_turtle?)
+    end
+
+    specify "can be enabled in configuration" do
+      fake_geolexica_config["formats"] = %w[html json json-ld turtle]
+
+      expect(wrapper.output_html?).to be(true)
+      expect(wrapper.output_json?).to be(true)
+      expect(wrapper.output_jsonld?).to be(true)
+      expect(wrapper.output_turtle?).to be(true)
+    end
+
+    specify "can be disabled in configuration" do
+      fake_geolexica_config["formats"] = []
+
+      expect(wrapper.output_html?).to be(false)
+      expect(wrapper.output_json?).to be(false)
+      expect(wrapper.output_jsonld?).to be(false)
+      expect(wrapper.output_turtle?).to be(false)
+    end
+  end
+
   def load_plugin_config
     path = File.expand_path("../../../../_config.yml", __dir__)
     yaml = File.read(path)


### PR DESCRIPTION
Add brand new `geolexica.formats` option. It allows to specify in which formats concept pages and some meta pages are generated.