### PR TITLE
Fix language maps in JSON-LD

### DIFF
--- a/_layouts/concept.jsonld.html
+++ b/_layouts/concept.jsonld.html
@@ -22,7 +22,7 @@ layout: null
     {%- assign localized_term = page[lang] -%}
     {%- if localized_term.term -%}
     {
-      "@language": "{{ lang }}",
+      "@language": "{{ site.data.lang[lang].iso-639-1 }}",
       "@value": "{{ localized_term.term | escape }}"
     }{% unless forloop.last %},{% endunless %}
     {%- endif -%}
@@ -34,7 +34,7 @@ layout: null
     {%- assign localized_term = page[lang] -%}
     {%- if localized_term.alt -%}
     {
-      "@language": "{{ lang }}",
+      "@language": "{{ site.data.lang[lang].iso-639-1 }}",
       "@value": "{{ localized_term.alt | escape }}"
     }{% unless forloop.last %},{% endunless %}
     {%- endif -%}
@@ -46,7 +46,7 @@ layout: null
     {%- assign localized_term = page[lang] -%}
     {%- if localized_term.definition -%}
     {
-      "@language": "{{ lang }}",
+      "@language": "{{ site.data.lang[lang].iso-639-1 }}",
       "@value": "{{ localized_term.definition | escape }}"
     }{% unless forloop.last %},{% endunless %}
     {%- endif -%}
@@ -74,7 +74,7 @@ layout: null
       {
         "note-id": {{ notenum }},
         "note": {
-          "@language": "{{ lang }}",
+          "@language": "{{ site.data.lang[lang].iso-639-1 }}",
           "@type": "skos:note",
           {%- if lang != "eng" and note == concept.notes[forloop.index0] -%}
           "@value": "notTranslated",
@@ -104,7 +104,7 @@ layout: null
       {
         "example-id": {{ examplenum }},
         "example": {
-          "@language": "{{ lang }}",
+          "@language": "{{ site.data.lang[lang].iso-639-1 }}",
           "@type": "skos:example",
           {%- if lang != "eng" and example == concept.examples[forloop.index0] -%}
           "@value": "notTranslated",


### PR DESCRIPTION
Language tags in JSON-LD (i.e. keys in language maps) must follow [BCP47], that is ISO 639-1 codes can be used, but ISO 639-2 cannot.

See:

- https://www.w3.org/TR/json-ld/#language-maps
- https://tools.ietf.org/html/bcp47
- http://www.loc.gov/standards/iso639-2/php/code_list.php

This was originally implemented by Ronald Tse in 5ece623aa603feb.