### PR TITLE
Add a stub of TBX-ISO-TML output format feature

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -47,6 +47,9 @@ collections:
   concepts_ttl:
     output: true
     output_ext: .ttl
+  concepts_tbx:
+    output: true
+    output_ext: .tbx.xml
 
 geolexica:
   concepts_glob: "./geolexica-database/concepts/*.yaml"

--- a/_layouts/concept.html
+++ b/_layouts/concept.html
@@ -79,12 +79,14 @@ term_attributes:
 </section>
 {%- endif %}
 
+{% if site.geolexica.formats contains 'tbx-iso-tml' -%}
 {% assign tbx_concept = site.concepts_tbx | where: 'termid', page.termid | first -%}
 {% assign tbx_url = tbx_concept.url -%}
 <section class="field tbx">
   <p class="field-name">TBX-ISO-TML</p>
   <p class="field-value"><a href="{{ tbx_url }}">{{ tbx_url }}</a></p>
 </section>
+{%- endif %}
 
 <section class="field info">
   <p class="field-name">info</p>

--- a/_layouts/concept.html
+++ b/_layouts/concept.html
@@ -79,6 +79,13 @@ term_attributes:
 </section>
 {%- endif %}
 
+{% assign tbx_concept = site.concepts_tbx | where: 'termid', page.termid | first -%}
+{% assign tbx_url = tbx_concept.url -%}
+<section class="field tbx">
+  <p class="field-name">TBX-ISO-TML</p>
+  <p class="field-value"><a href="{{ tbx_url }}">{{ tbx_url }}</a></p>
+</section>
+
 <section class="field info">
   <p class="field-name">info</p>
   <div class="field-value">

--- a/lib/jekyll/geolexica/concept_page.rb
+++ b/lib/jekyll/geolexica/concept_page.rb
@@ -98,6 +98,25 @@ module Jekyll
           "/api/concepts/#{termid}.ttl"
         end
       end
+
+      class TBX < ConceptPage
+        def page_name
+          "#{termid}.tbx.xml"
+        end
+
+        def collection_name
+          "concepts_tbx"
+        end
+
+        def layout
+          "concept.tbx.xml"
+        end
+
+        def permalink
+          "/api/concepts/#{termid}.tbx.xml"
+        end
+      end
+
     end
   end
 end

--- a/lib/jekyll/geolexica/concepts_generator.rb
+++ b/lib/jekyll/geolexica/concepts_generator.rb
@@ -35,7 +35,7 @@ module Jekyll
           add_page ConceptPage::HTML.new(site, concept_hash) if output_html?
           add_page ConceptPage::JSON.new(site, concept_hash) if output_json?
           add_page ConceptPage::JSONLD.new(site, concept_hash) if output_jsonld?
-          add_page ConceptPage::TBX.new(site, concept_hash)
+          add_page ConceptPage::TBX.new(site, concept_hash) if output_tbx?
           add_page ConceptPage::Turtle.new(site, concept_hash) if output_turtle?
         end
       end

--- a/lib/jekyll/geolexica/concepts_generator.rb
+++ b/lib/jekyll/geolexica/concepts_generator.rb
@@ -35,6 +35,7 @@ module Jekyll
           add_page ConceptPage::HTML.new(site, concept_hash) if output_html?
           add_page ConceptPage::JSON.new(site, concept_hash) if output_json?
           add_page ConceptPage::JSONLD.new(site, concept_hash) if output_jsonld?
+          add_page ConceptPage::TBX.new(site, concept_hash)
           add_page ConceptPage::Turtle.new(site, concept_hash) if output_turtle?
         end
       end

--- a/lib/jekyll/geolexica/configuration.rb
+++ b/lib/jekyll/geolexica/configuration.rb
@@ -21,6 +21,10 @@ module Jekyll
         glossary_config["formats"].include?("json-ld")
       end
 
+      def output_tbx?
+        glossary_config["formats"].include?("tbx-iso-tml")
+      end
+
       def output_turtle?
         glossary_config["formats"].include?("turtle")
       end


### PR DESCRIPTION
This pull request adds some basic classes for TBX-ISO-TML output so that sites can have some partial support without patching `Jekyll::Geolexica`. Sites still need to provide their own `_layout/concept.tbx.xml.html` layout though.

See #36.

----

This is basically for Electropedia, so that its dedicated branch can be gradually unwinded.