### PR TITLE
Allow for page content in custom-home layout

### DIFF
--- a/_layouts/custom-home.html
+++ b/_layouts/custom-home.html
@@ -20,6 +20,8 @@ extra_scripts:
   <a href="/concepts/" class="browse-concepts">Browse concepts</a>
 </section>
 
+{{ content }}
+
 <section class="news">
   <h2 class="section-title">News</h2>
 


### PR DESCRIPTION
Merge in a change which was meant for IEV site as it is generally very useful.

This pull request brings the ability of embedding page content in custom-home layout, that is turns it into a "true" layout.