### PR TITLE
Fix and update languages list

### DIFF
--- a/_data/lang.yaml
+++ b/_data/lang.yaml
@@ -10,7 +10,7 @@ ara:
   iso-639-1: ar
   example: "مثال"
   note_to_entry: "ملاحظة DD:"
-chn:
+zho:
   lang_native: 中文
   lang_en: Chinese
   iso-639-1: zh
@@ -22,7 +22,7 @@ dan:
   iso-639-1: da
   example: EKSEMPEL
   note_to_entry: "NOTE DD to entry:"
-dut:
+nld:
   lang_native: Nederlands
   lang_en: Dutch
   iso-639-1: nl
@@ -40,7 +40,7 @@ fra:
   iso-639-1: fr
   example: EXEMPLE
   note_to_entry: "A noter DD:"
-ger:
+deu:
   lang_native: Deutsch
   lang_en: German
   iso-639-1: de
@@ -49,13 +49,13 @@ ger:
 jpn:
   lang_native: 日本語
   lang_en: Japanese
-  iso-639-1: jp
+  iso-639-1: ja
   example: 例
   note_to_entry: "備考 DD："
 kor:
   lang_native: 한국어
   lang_en: Korean
-  iso-639-1: kr
+  iso-639-1: ko
   example: 보기
   note_to_entry: "비고 DD:"
 msa:

--- a/_data/lang.yaml
+++ b/_data/lang.yaml
@@ -9,7 +9,7 @@ dan:
   lang_en: Danish
   iso-639-1: da
   example: EKSEMPEL
-  note_to_entry: "NOTE DD to entry:"
+  note_to_entry: "Bemærk DD til posten:"
 deu:
   lang_native: Deutsch
   lang_en: German
@@ -33,7 +33,7 @@ fra:
   lang_en: French
   iso-639-1: fr
   example: EXEMPLE
-  note_to_entry: "A noter DD:"
+  note_to_entry: "Note DD à l'article:"
 jpn:
   lang_native: 日本語
   lang_en: Japanese
@@ -64,6 +64,12 @@ pol:
   iso-639-1: pl
   example: PRZYKŁAD
   note_to_entry: "UWAGA DD:"
+por:
+  lang_native: português
+  lang_en: Portuguese
+  iso-639-1: pt
+  exemplo: EXEMPLO
+  note_to_entry: "Anote o DD na entrada:"
 rus:
   lang_native: Русский язык
   lang_en: Russian

--- a/_data/lang.yaml
+++ b/_data/lang.yaml
@@ -1,33 +1,27 @@
-eng:
-  lang_native: English
-  lang_en: English
-  iso-639-1: en
-  example: EXAMPLE
-  note_to_entry: "Note DD to entry:"
 ara:
   lang_native: العربية
   lang_en: Arabic
   iso-639-1: ar
   example: "مثال"
   note_to_entry: "ملاحظة DD:"
-zho:
-  lang_native: 中文
-  lang_en: Chinese
-  iso-639-1: zh
-  example: 示例
-  note_to_entry: "注 DD："
 dan:
   lang_native: dansk
   lang_en: Danish
   iso-639-1: da
   example: EKSEMPEL
   note_to_entry: "NOTE DD to entry:"
-nld:
-  lang_native: Nederlands
-  lang_en: Dutch
-  iso-639-1: nl
-  example: VOORBEELD
-  note_to_entry: "OPMERKING DD:"
+deu:
+  lang_native: Deutsch
+  lang_en: German
+  iso-639-1: de
+  example: BEISPIEL
+  note_to_entry: "NOTE DD:"
+eng:
+  lang_native: English
+  lang_en: English
+  iso-639-1: en
+  example: EXAMPLE
+  note_to_entry: "Note DD to entry:"
 fin:
   lang_native: suomi
   lang_en: Finnish
@@ -40,12 +34,6 @@ fra:
   iso-639-1: fr
   example: EXEMPLE
   note_to_entry: "A noter DD:"
-deu:
-  lang_native: Deutsch
-  lang_en: German
-  iso-639-1: de
-  example: BEISPIEL
-  note_to_entry: "NOTE DD:"
 jpn:
   lang_native: 日本語
   lang_en: Japanese
@@ -64,6 +52,12 @@ msa:
   iso-639-1: ms
   example: Contoh
   note_to_entry: "catatan DD:"
+nld:
+  lang_native: Nederlands
+  lang_en: Dutch
+  iso-639-1: nl
+  example: VOORBEELD
+  note_to_entry: "OPMERKING DD:"
 pol:
   lang_native: polski
   lang_en: Polish
@@ -88,3 +82,9 @@ swe:
   iso-639-1: sv
   example: EXEMPEL
   note_to_entry: "Anm. DD till termpost:"
+zho:
+  lang_native: 中文
+  lang_en: Chinese
+  iso-639-1: zh
+  example: 示例
+  note_to_entry: "注 DD："


### PR DESCRIPTION
- Replace ISO 639-2 codes with correct ones for terminology.
- Replace ISO 639-1 codes with correct ones.
- Order languages alphabetically (by their ISO 639-2 code).
- Add Portuguese language.
- Some other updates from @ronaldtse.

It is very important to sort out our languages map because there are too many discrepancies between sites which already led to some issues.

This is going to affect all geolexica/glossarist sites eventually. For sites which need to customize language selection or ordering, it can be done in `_config.yml`.