### PR TITLE
Define Jekyll::Site.glossary

### DIFF
--- a/lib/jekyll/geolexica.rb
+++ b/lib/jekyll/geolexica.rb
@@ -11,4 +11,8 @@ end
 require_relative "geolexica/configuration"
 require_relative "geolexica/concept_page"
 require_relative "geolexica/concepts_generator"
+require_relative "geolexica/glossary"
+require_relative "geolexica/hooks"
 require_relative "geolexica/meta_pages_generator"
+
+Jekyll::Geolexica::Hooks.register_all_hooks

--- a/lib/jekyll/geolexica/concept_page.rb
+++ b/lib/jekyll/geolexica/concept_page.rb
@@ -4,17 +4,17 @@
 module Jekyll
   module Geolexica
     class ConceptPage < PageWithoutAFile
-      attr_reader :concept_hash
+      attr_reader :concept
 
-      def initialize(site, concept_hash)
-        @concept_hash = concept_hash
-        @data = default_data.merge(concept_hash)
+      def initialize(site, concept)
+        @concept = concept
+        @data = default_data.merge(concept.data)
 
         super(site, site.source, "concepts", page_name)
       end
 
       def termid
-        concept_hash["termid"]
+        concept.data["termid"]
       end
 
       def type

--- a/lib/jekyll/geolexica/concept_page.rb
+++ b/lib/jekyll/geolexica/concept_page.rb
@@ -14,7 +14,7 @@ module Jekyll
       end
 
       def termid
-        concept.data["termid"]
+        concept.termid
       end
 
       def type

--- a/lib/jekyll/geolexica/concepts_generator.rb
+++ b/lib/jekyll/geolexica/concepts_generator.rb
@@ -30,11 +30,11 @@ module Jekyll
         site.glossary.each_concept do |concept|
           Jekyll.logger.debug("Geolexica:",
             "building pages for concept #{concept.data["termid"]}")
-          add_page ConceptPage::HTML.new(site, concept.data) if output_html?
-          add_page ConceptPage::JSON.new(site, concept.data) if output_json?
-          add_page ConceptPage::JSONLD.new(site, concept.data) if output_jsonld?
-          add_page ConceptPage::TBX.new(site, concept.data) if output_tbx?
-          add_page ConceptPage::Turtle.new(site, concept.data) if output_turtle?
+          add_page ConceptPage::HTML.new(site, concept) if output_html?
+          add_page ConceptPage::JSON.new(site, concept) if output_json?
+          add_page ConceptPage::JSONLD.new(site, concept) if output_jsonld?
+          add_page ConceptPage::TBX.new(site, concept) if output_tbx?
+          add_page ConceptPage::Turtle.new(site, concept) if output_turtle?
         end
       end
 

--- a/lib/jekyll/geolexica/concepts_generator.rb
+++ b/lib/jekyll/geolexica/concepts_generator.rb
@@ -29,7 +29,7 @@ module Jekyll
       def make_pages
         site.glossary.each_concept do |concept|
           Jekyll.logger.debug("Geolexica:",
-            "building pages for concept #{concept.data["termid"]}")
+            "building pages for concept #{concept.termid}")
           add_page ConceptPage::HTML.new(site, concept) if output_html?
           add_page ConceptPage::JSON.new(site, concept) if output_json?
           add_page ConceptPage::JSONLD.new(site, concept) if output_jsonld?

--- a/lib/jekyll/geolexica/concepts_generator.rb
+++ b/lib/jekyll/geolexica/concepts_generator.rb
@@ -27,16 +27,14 @@ module Jekyll
 
       # Processes concepts and yields a bunch of Jekyll::Page instances.
       def make_pages
-        Dir.glob(concepts_glob).each do |concept_file_path|
+        site.glossary.each_concept do |concept|
           Jekyll.logger.debug("Geolexica:",
-            "processing concept data #{concept_file_path}")
-          concept_hash = read_concept_file(concept_file_path)
-          preprocess_concept_hash(concept_hash)
-          add_page ConceptPage::HTML.new(site, concept_hash) if output_html?
-          add_page ConceptPage::JSON.new(site, concept_hash) if output_json?
-          add_page ConceptPage::JSONLD.new(site, concept_hash) if output_jsonld?
-          add_page ConceptPage::TBX.new(site, concept_hash) if output_tbx?
-          add_page ConceptPage::Turtle.new(site, concept_hash) if output_turtle?
+            "building pages for concept #{concept.data["termid"]}")
+          add_page ConceptPage::HTML.new(site, concept.data) if output_html?
+          add_page ConceptPage::JSON.new(site, concept.data) if output_json?
+          add_page ConceptPage::JSONLD.new(site, concept.data) if output_jsonld?
+          add_page ConceptPage::TBX.new(site, concept.data) if output_tbx?
+          add_page ConceptPage::Turtle.new(site, concept.data) if output_turtle?
         end
       end
 
@@ -56,15 +54,6 @@ module Jekyll
 
       def find_page(name)
         site.pages.detect { |page| page.name == name }
-      end
-
-      # Reads and parses concept file located at given path.
-      def read_concept_file(path)
-        YAML.load(File.read path)
-      end
-
-      # Does nothing, but some sites may replace this method.
-      def preprocess_concept_hash(concept_hash)
       end
     end
   end

--- a/lib/jekyll/geolexica/glossary.rb
+++ b/lib/jekyll/geolexica/glossary.rb
@@ -53,6 +53,10 @@ module Jekyll
         def initialize(data)
           @data = data
         end
+
+        def termid
+          data["termid"]
+        end
       end
     end
   end

--- a/lib/jekyll/geolexica/glossary.rb
+++ b/lib/jekyll/geolexica/glossary.rb
@@ -14,6 +14,46 @@ module Jekyll
       def initialize(site)
         @site = site
       end
+
+      def load_glossary
+        Jekyll.logger.info("Geolexica:", "Loading concepts")
+        Dir.glob(concepts_glob).each { |path| load_concept(path) }
+      end
+
+      def store(concept)
+        super(concept.data["termid"], concept)
+      end
+
+      protected
+
+      def load_concept(concept_file_path)
+        Jekyll.logger.debug("Geolexica:",
+          "reading concept from file #{concept_file_path}")
+        concept_hash = read_concept_file(concept_file_path)
+        preprocess_concept_hash(concept_hash)
+        store Concept.new(concept_hash)
+      rescue
+        Jekyll.logger.error("Geolexica:",
+          "failed to read concept from file #{concept_file_path}")
+        raise
+      end
+
+      # Reads and parses concept file located at given path.
+      def read_concept_file(path)
+        YAML.load(File.read path)
+      end
+
+      # Does nothing, but some sites may replace this method.
+      def preprocess_concept_hash(concept_hash)
+      end
+
+      class Concept
+        attr_reader :data
+
+        def initialize(data)
+          @data = data
+        end
+      end
     end
   end
 end

--- a/lib/jekyll/geolexica/glossary.rb
+++ b/lib/jekyll/geolexica/glossary.rb
@@ -1,0 +1,19 @@
+# (c) Copyright 2020 Ribose Inc.
+#
+
+module Jekyll
+  module Geolexica
+    class Glossary < Hash
+      include Configuration
+
+      attr_reader :site
+
+      alias_method :each_concept, :each_value
+      alias_method :each_termid, :each_key
+
+      def initialize(site)
+        @site = site
+      end
+    end
+  end
+end

--- a/lib/jekyll/geolexica/hooks.rb
+++ b/lib/jekyll/geolexica/hooks.rb
@@ -5,12 +5,18 @@ module Jekyll
 
       def register_all_hooks
         Jekyll::Hooks.register :site, :after_init, &method(:initialize_glossary)
+        Jekyll::Hooks.register :site, :post_read, &method(:load_glossary)
       end
 
       # Adds Jekyll::Site#glossary method, and initializes an empty glossary.
       def initialize_glossary(site)
         site.class.attr_reader :glossary
         site.instance_variable_set "@glossary", Glossary.new(site)
+      end
+
+      # Loads concept data into glossary.
+      def load_glossary(site)
+        site.glossary.load_glossary
       end
     end
   end

--- a/lib/jekyll/geolexica/hooks.rb
+++ b/lib/jekyll/geolexica/hooks.rb
@@ -1,0 +1,17 @@
+module Jekyll
+  module Geolexica
+    module Hooks
+      module_function
+
+      def register_all_hooks
+        Jekyll::Hooks.register :site, :after_init, &method(:initialize_glossary)
+      end
+
+      # Adds Jekyll::Site#glossary method, and initializes an empty glossary.
+      def initialize_glossary(site)
+        site.class.attr_reader :glossary
+        site.instance_variable_set "@glossary", Glossary.new(site)
+      end
+    end
+  end
+end

--- a/spec/unit/jekyll/geolexica/glossary_spec.rb
+++ b/spec/unit/jekyll/geolexica/glossary_spec.rb
@@ -1,0 +1,12 @@
+# (c) Copyright 2020 Ribose Inc.
+#
+
+RSpec.describe ::Jekyll::Geolexica::Glossary do
+  subject { instance }
+
+  let(:instance) { described_class.new(fake_site) }
+  let(:fake_site) { instance_double(Jekyll::Site) }
+
+  it { is_expected.to respond_to(:each_concept) }
+  it { is_expected.to respond_to(:each_termid) }
+end


### PR DESCRIPTION
Define `Glossary` class which provides a more elegant access to concepts.