### PR TITLE
Serialize concepts in YAML format

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -50,6 +50,9 @@ collections:
   concepts_tbx:
     output: true
     output_ext: .tbx.xml
+  concepts_yaml:
+    output: true
+    output_ext: .yaml
 
 geolexica:
   concepts_glob: "./geolexica-database/concepts/*.yaml"

--- a/_layouts/concept.html
+++ b/_layouts/concept.html
@@ -61,6 +61,15 @@ term_attributes:
 </section>
 {%- endif %}
 
+{% if site.geolexica.formats contains 'json' -%}
+{% assign yaml_concept = site.concepts_yaml | where: 'termid', page.termid | first -%}
+{% assign yaml_url = yaml_concept.url -%}
+<section class="field yaml">
+  <p class="field-name">YAML</p>
+  <p class="field-value"><a href="{{ yaml_url }}">{{ yaml_url }}</a></p>
+</section>
+{%- endif %}
+
 {% if site.geolexica.formats contains 'json-ld' -%}
 {% assign json_concept = site.concepts_jsonld | where: 'termid', page.termid | first -%}
 {% assign json_url = json_concept.url -%}

--- a/lib/jekyll/geolexica/concept_page.rb
+++ b/lib/jekyll/geolexica/concept_page.rb
@@ -137,6 +137,29 @@ module Jekyll
         end
       end
 
+      class YAML < ConceptPage
+        def page_name
+          "#{termid}.yaml"
+        end
+
+        def collection_name
+          "concepts_yaml"
+        end
+
+        def layout
+          nil
+        end
+
+        def content
+          s = ConceptSerializer.new(concept, site)
+          escape_liquid(s.to_yaml)
+        end
+
+        def permalink
+          "/api/concepts/#{termid}.yaml"
+        end
+      end
+
     end
   end
 end

--- a/lib/jekyll/geolexica/concept_serializer.rb
+++ b/lib/jekyll/geolexica/concept_serializer.rb
@@ -19,6 +19,10 @@ module Jekyll
         JSON.dump(in_all_languages)
       end
 
+      def to_yaml
+        YAML.dump(in_all_languages)
+      end
+
       private
 
       # Returns concept hash in all supported languages, with +nil+ value for

--- a/lib/jekyll/geolexica/concepts_generator.rb
+++ b/lib/jekyll/geolexica/concepts_generator.rb
@@ -35,6 +35,7 @@ module Jekyll
           add_page ConceptPage::JSONLD.new(site, concept) if output_jsonld?
           add_page ConceptPage::TBX.new(site, concept) if output_tbx?
           add_page ConceptPage::Turtle.new(site, concept) if output_turtle?
+          add_page ConceptPage::YAML.new(site, concept) if output_yaml?
         end
       end
 

--- a/lib/jekyll/geolexica/configuration.rb
+++ b/lib/jekyll/geolexica/configuration.rb
@@ -33,6 +33,10 @@ module Jekyll
         glossary_config["formats"].include?("turtle")
       end
 
+      def output_yaml?
+        glossary_config["formats"].include?("yaml")
+      end
+
       protected
 
       def glossary_config

--- a/spec/unit/jekyll/geolexica/concept_serializer_spec.rb
+++ b/spec/unit/jekyll/geolexica/concept_serializer_spec.rb
@@ -50,4 +50,23 @@ RSpec.describe ::Jekyll::Geolexica::ConceptSerializer do
       expect(parsed_retval["unknown"]).to be_nil
     end
   end
+
+  describe "#to_yaml" do
+    subject { described_class.instance_method(:to_yaml) }
+
+    it "returns a YAML in expected format" do
+      retval = subject.bind(serializer_10).call
+      expect(retval).to be_kind_of(String) & start_with("---\n")
+      expect { YAML.parse(retval) }.not_to raise_error # be valid YAML
+
+      parsed_retval = YAML.load retval
+
+      expect(parsed_retval.keys).to contain_exactly(
+        "term", "termid", "eng", "jpn", "pol", "unknown")
+      expect(parsed_retval["term"]).to eq(concept_10.data["term"])
+      expect(parsed_retval["termid"]).to eq(concept_10.data["termid"])
+      expect(parsed_retval["eng"]).to eq(concept_10.data["eng"])
+      expect(parsed_retval.fetch("unknown", :missing)).to be_nil
+    end
+  end
 end

--- a/spec/unit/jekyll/geolexica/configuration_spec.rb
+++ b/spec/unit/jekyll/geolexica/configuration_spec.rb
@@ -74,17 +74,19 @@ RSpec.describe ::Jekyll::Geolexica::Configuration do
       expect(wrapper).to respond_to(:output_jsonld?)
       expect(wrapper).to respond_to(:output_tbx?)
       expect(wrapper).to respond_to(:output_turtle?)
+      expect(wrapper).to respond_to(:output_yaml?)
     end
 
     specify "can be enabled in configuration" do
       fake_geolexica_config["formats"] =
-        %w[html json json-ld tbx-iso-tml turtle]
+        %w[html json json-ld tbx-iso-tml turtle yaml]
 
       expect(wrapper.output_html?).to be(true)
       expect(wrapper.output_json?).to be(true)
       expect(wrapper.output_jsonld?).to be(true)
       expect(wrapper.output_tbx?).to be(true)
       expect(wrapper.output_turtle?).to be(true)
+      expect(wrapper.output_yaml?).to be(true)
     end
 
     specify "can be disabled in configuration" do
@@ -95,6 +97,7 @@ RSpec.describe ::Jekyll::Geolexica::Configuration do
       expect(wrapper.output_jsonld?).to be(false)
       expect(wrapper.output_tbx?).to be(false)
       expect(wrapper.output_turtle?).to be(false)
+      expect(wrapper.output_yaml?).to be(false)
     end
   end
 


### PR DESCRIPTION
Concepts are now available in YAML format at `/api/concepts/<termid>.yaml`. Fixes #52.