### PR TITLE
Optimize site generation

### DIFF
--- a/_layouts/concept.html
+++ b/_layouts/concept.html
@@ -52,40 +52,40 @@ term_attributes:
 
 {% endfor %}
 
-{% if site.geolexica.formats contains 'json' -%}
 {% assign json_url = page.representations.json.url -%}
+{% if json_url -%}
 <section class="field json">
   <p class="field-name">JSON</p>
   <p class="field-value"><a href="{{ json_url }}">{{ json_url }}</a></p>
 </section>
 {%- endif %}
 
-{% if site.geolexica.formats contains 'yaml' -%}
 {% assign yaml_url = page.representations.yaml.url -%}
+{% if yaml_url -%}
 <section class="field yaml">
   <p class="field-name">YAML</p>
   <p class="field-value"><a href="{{ yaml_url }}">{{ yaml_url }}</a></p>
 </section>
 {%- endif %}
 
-{% if site.geolexica.formats contains 'json-ld' -%}
 {% assign json_url = page.representations.jsonld.url -%}
+{% if json_url -%}
 <section class="field json">
   <p class="field-name">SKOS in JSON-LD</p>
   <p class="field-value"><a href="{{ json_url }}">{{ json_url }}</a></p>
 </section>
 {%- endif %}
 
-{% if site.geolexica.formats contains 'turtle' -%}
 {% assign ttl_url = page.representations.turtle.url -%}
+{% if ttl_url -%}
 <section class="field ttl">
   <p class="field-name">SKOS in RDF</p>
   <p class="field-value"><a href="{{ ttl_url }}">{{ ttl_url }}</a></p>
 </section>
 {%- endif %}
 
-{% if site.geolexica.formats contains 'tbx-iso-tml' -%}
 {% assign tbx_url = page.representations.tbx.url -%}
+{% if tbx_url -%}
 <section class="field tbx">
   <p class="field-name">TBX-ISO-TML</p>
   <p class="field-value"><a href="{{ tbx_url }}">{{ tbx_url }}</a></p>

--- a/_layouts/concept.html
+++ b/_layouts/concept.html
@@ -53,8 +53,7 @@ term_attributes:
 {% endfor %}
 
 {% if site.geolexica.formats contains 'json' -%}
-{% assign json_concept = site.concepts_json | where: 'termid', page.termid | first -%}
-{% assign json_url = json_concept.url -%}
+{% assign json_url = page.representations.json.url -%}
 <section class="field json">
   <p class="field-name">JSON</p>
   <p class="field-value"><a href="{{ json_url }}">{{ json_url }}</a></p>
@@ -62,8 +61,7 @@ term_attributes:
 {%- endif %}
 
 {% if site.geolexica.formats contains 'yaml' -%}
-{% assign yaml_concept = site.concepts_yaml | where: 'termid', page.termid | first -%}
-{% assign yaml_url = yaml_concept.url -%}
+{% assign yaml_url = page.representations.yaml.url -%}
 <section class="field yaml">
   <p class="field-name">YAML</p>
   <p class="field-value"><a href="{{ yaml_url }}">{{ yaml_url }}</a></p>
@@ -71,8 +69,7 @@ term_attributes:
 {%- endif %}
 
 {% if site.geolexica.formats contains 'json-ld' -%}
-{% assign json_concept = site.concepts_jsonld | where: 'termid', page.termid | first -%}
-{% assign json_url = json_concept.url -%}
+{% assign json_url = page.representations.jsonld.url -%}
 <section class="field json">
   <p class="field-name">SKOS in JSON-LD</p>
   <p class="field-value"><a href="{{ json_url }}">{{ json_url }}</a></p>
@@ -80,8 +77,7 @@ term_attributes:
 {%- endif %}
 
 {% if site.geolexica.formats contains 'turtle' -%}
-{% assign ttl_concept = site.concepts_ttl | where: 'termid', page.termid | first -%}
-{% assign ttl_url = ttl_concept.url -%}
+{% assign ttl_url = page.representations.turtle.url -%}
 <section class="field ttl">
   <p class="field-name">SKOS in RDF</p>
   <p class="field-value"><a href="{{ ttl_url }}">{{ ttl_url }}</a></p>
@@ -89,8 +85,7 @@ term_attributes:
 {%- endif %}
 
 {% if site.geolexica.formats contains 'tbx-iso-tml' -%}
-{% assign tbx_concept = site.concepts_tbx | where: 'termid', page.termid | first -%}
-{% assign tbx_url = tbx_concept.url -%}
+{% assign tbx_url = page.representations.tbx.url -%}
 <section class="field tbx">
   <p class="field-name">TBX-ISO-TML</p>
   <p class="field-value"><a href="{{ tbx_url }}">{{ tbx_url }}</a></p>

--- a/_layouts/concept.ttl.html
+++ b/_layouts/concept.ttl.html
@@ -3,7 +3,7 @@ layout: null
 ---
 {%- assign concept = page["eng"] -%}
 {%- assign rdfprofile = "/api/rdf-profile" -%}
-{%- assign concept_html = site.concepts | where: 'termid', page.termid | first -%}
+{%- assign concept_html = page.representations.html -%}
 {%- assign concept_id = concept_html.url -%}
 {%- assign english = page["eng"] -%}
 # baseURI: "{{ concept_id }}"

--- a/_pages/concepts-index.json
+++ b/_pages/concepts-index.json
@@ -3,7 +3,7 @@ permalink: "/api/concepts.json"
 ---
 {
   {% for concept in site.concepts %}
-  {% assign json_concept = site.concepts_json | where: 'termid', concept.termid | first %}
+  {% assign json_concept = concept.representations.json %}
   "{{ concept.termid }}": {
     "term": "{{ concept.term }}",
     "termid": {{ concept.termid }},

--- a/lib/jekyll/geolexica/concept_page.rb
+++ b/lib/jekyll/geolexica/concept_page.rb
@@ -27,6 +27,7 @@ module Jekyll
         {
           "layout" => layout,
           "permalink" => permalink,
+          "representations" => concept.pages,
         }
       end
 

--- a/lib/jekyll/geolexica/concept_page.rb
+++ b/lib/jekyll/geolexica/concept_page.rb
@@ -24,7 +24,10 @@ module Jekyll
       protected
 
       def default_data
-        {"layout" => layout, "permalink" => permalink}
+        {
+          "layout" => layout,
+          "permalink" => permalink,
+        }
       end
 
       # Disables Liquid processing for given content.

--- a/lib/jekyll/geolexica/concepts_generator.rb
+++ b/lib/jekyll/geolexica/concepts_generator.rb
@@ -30,12 +30,15 @@ module Jekyll
         site.glossary.each_concept do |concept|
           Jekyll.logger.debug("Geolexica:",
             "building pages for concept #{concept.termid}")
-          add_page ConceptPage::HTML.new(site, concept) if output_html?
-          add_page ConceptPage::JSON.new(site, concept) if output_json?
-          add_page ConceptPage::JSONLD.new(site, concept) if output_jsonld?
-          add_page ConceptPage::TBX.new(site, concept) if output_tbx?
-          add_page ConceptPage::Turtle.new(site, concept) if output_turtle?
-          add_page ConceptPage::YAML.new(site, concept) if output_yaml?
+          concept.pages.replace({
+            html: (ConceptPage::HTML.new(site, concept) if output_html?),
+            json: (ConceptPage::JSON.new(site, concept) if output_json?),
+            jsonld: (ConceptPage::JSONLD.new(site, concept) if output_jsonld?),
+            tbx: (ConceptPage::TBX.new(site, concept) if output_tbx?),
+            turtle: (ConceptPage::Turtle.new(site, concept) if output_turtle?),
+            yaml: (ConceptPage::YAML.new(site, concept) if output_yaml?),
+          })
+          add_page(*concept.pages.values.compact)
         end
       end
 

--- a/lib/jekyll/geolexica/glossary.rb
+++ b/lib/jekyll/geolexica/glossary.rb
@@ -50,8 +50,12 @@ module Jekyll
       class Concept
         attr_reader :data
 
+        # TODO Maybe some kind of Struct instead of Hash.
+        attr_reader :pages
+
         def initialize(data)
           @data = data
+          @pages = {}
         end
 
         def termid

--- a/lib/jekyll/geolexica/glossary.rb
+++ b/lib/jekyll/geolexica/glossary.rb
@@ -55,11 +55,17 @@ module Jekyll
 
         def initialize(data)
           @data = data
-          @pages = {}
+          @pages = LiquidCompatibleHash.new
         end
 
         def termid
           data["termid"]
+        end
+
+        class LiquidCompatibleHash < Hash
+          def to_liquid
+            Jekyll::Utils.stringify_hash_keys(self)
+          end
         end
       end
     end


### PR DESCRIPTION
Glossary concepts are now bi-directionally associated with respective pages, and this association is now used in templates instead of searching for proper page in collection with Liquid `where` filter, which has proven to be ridiculously slow.

All occurrences of `where` filter in the project have been replaced. Time required to build the whole site is reduced by an order of magnitude. Fixes #71.