### PR TITLE
Rework computing language statistics

### DIFF
--- a/_pages/stats.adoc
+++ b/_pages/stats.adoc
@@ -10,13 +10,7 @@ title: Statistics
 The following languages are provided in Geolexica, with the number of terms displayed below.
 
 {% for lang in site.geolexica.term_languages %}
-{% assign lang = lang_pair[0] %}
-{% assign counter = 0 %}
-{% for concept in site.concepts %}
-  {% unless concept[lang] == nil or concept[lang] == "" %}
-  {% assign counter = counter | plus: 1 %}
-  {% endunless %}
-{% endfor %}
+{% assign counter = glossary.language_statistics[lang] %}
 * {{ site.data.lang[lang].lang_native }}{% if lang != "eng" %} ({{ site.data.lang[lang].lang_en }}){% endif %}: {{ counter }}
 {% endfor %}
 

--- a/_pages/stats.json
+++ b/_pages/stats.json
@@ -2,15 +2,4 @@
 permalink: "/api/stats.json"
 layout: null
 ---
-{
-  {% for lang in site.geolexica.term_languages %}
-  {%- assign counter = 0 -%}
-  {%- for concept in site.concepts -%}
-    {% unless concept[lang] == nil or concept[lang] == "" %}
-    {% assign counter = counter | plus: 1 %}
-    {% endunless %}
-  {%- endfor -%}
-  "{{ lang }}": {{ counter }}{% unless forloop.last %},{% endunless %}
-  {% endfor %}
-}
-
+{{ glossary.language_statistics | jsonify }}

--- a/lib/jekyll/geolexica/glossary.rb
+++ b/lib/jekyll/geolexica/glossary.rb
@@ -59,10 +59,14 @@ module Jekyll
       end
 
       def calculate_language_statistics
-        each_value.lazy.
+        unsorted = each_value.lazy.
           flat_map{ |concept| term_languages & concept.data.keys }.
           group_by(&:itself).
           transform_values(&:count)
+
+        # This is not crucial, but gives nicer output, and ensures that
+        # all +term_languages+ are present.
+        term_languages.to_h { |key| [key, unsorted[key] || 0] }
       end
 
       class Concept

--- a/lib/jekyll/geolexica/glossary.rb
+++ b/lib/jekyll/geolexica/glossary.rb
@@ -31,7 +31,7 @@ module Jekyll
       # Defines how Glossary is exposed in Liquid templates.
       def to_liquid
         {
-          # TODO
+          "language_statistics" => language_statistics,
         }
       end
 

--- a/lib/jekyll/geolexica/glossary.rb
+++ b/lib/jekyll/geolexica/glossary.rb
@@ -24,6 +24,10 @@ module Jekyll
         super(concept.data["termid"], concept)
       end
 
+      def language_statistics
+        @language_statistics ||= calculate_language_statistics
+      end
+
       protected
 
       def load_concept(concept_file_path)
@@ -45,6 +49,13 @@ module Jekyll
 
       # Does nothing, but some sites may replace this method.
       def preprocess_concept_hash(concept_hash)
+      end
+
+      def calculate_language_statistics
+        each_value.lazy.
+          flat_map{ |concept| term_languages & concept.data.keys }.
+          group_by(&:itself).
+          transform_values(&:count)
       end
 
       class Concept

--- a/lib/jekyll/geolexica/glossary.rb
+++ b/lib/jekyll/geolexica/glossary.rb
@@ -28,6 +28,13 @@ module Jekyll
         @language_statistics ||= calculate_language_statistics
       end
 
+      # Defines how Glossary is exposed in Liquid templates.
+      def to_liquid
+        {
+          # TODO
+        }
+      end
+
       protected
 
       def load_concept(concept_file_path)

--- a/lib/jekyll/geolexica/hooks.rb
+++ b/lib/jekyll/geolexica/hooks.rb
@@ -6,6 +6,8 @@ module Jekyll
       def register_all_hooks
         Jekyll::Hooks.register :site, :after_init, &method(:initialize_glossary)
         Jekyll::Hooks.register :site, :post_read, &method(:load_glossary)
+        Jekyll::Hooks.register :documents, :pre_render, &method(:expose_glossary)
+        Jekyll::Hooks.register :pages, :pre_render, &method(:expose_glossary)
       end
 
       # Adds Jekyll::Site#glossary method, and initializes an empty glossary.
@@ -18,6 +20,17 @@ module Jekyll
       def load_glossary(site)
         site.glossary.load_glossary
       end
+
+      def expose_glossary(page_or_document, liquid_drop)
+        liquid_drop["glossary"] = page_or_document.site.glossary
+      end
+
+      # def test(page, drop)
+      #   require "pry"
+      #   if page.basename =~ /stat/
+      #     binding.pry
+      #   end
+      # end
     end
   end
 end

--- a/spec/unit/jekyll/geolexica/glossary_spec.rb
+++ b/spec/unit/jekyll/geolexica/glossary_spec.rb
@@ -5,8 +5,39 @@ RSpec.describe ::Jekyll::Geolexica::Glossary do
   subject { instance }
 
   let(:instance) { described_class.new(fake_site) }
-  let(:fake_site) { instance_double(Jekyll::Site) }
+  let(:fake_site) { instance_double(Jekyll::Site, config: fake_config) }
+  let(:fake_config) { {} }
 
   it { is_expected.to respond_to(:each_concept) }
   it { is_expected.to respond_to(:each_termid) }
+
+  describe "#language_statistics" do
+    subject { instance.method(:language_statistics) }
+
+    let(:fake_config) do
+      {"geolexica" => { "term_languages" => %w[eng deu pol] }}
+    end
+
+    before do
+      add_concepts(
+        {"termid" => 1, "eng" => {}},
+        {"termid" => 2, "eng" => {}, "pol" => {}, },
+        {"termid" => 3, "eng" => {}, "deu" => {}, },
+        {"termid" => 4, "eng" => {}, "deu" => {}, },
+      )
+    end
+
+    it "returns a hash with languages as keys and natural numbers as values" do
+      retval = subject.call
+      expect(retval).to be_kind_of(Hash)
+      expect(retval.keys).to all be_kind_of(String) & have_attributes(size: 3)
+      expect(retval.values).to all be_kind_of(Integer) & (be >= 0)
+      expect(retval).to eq({"eng" => 4, "deu" => 2, "pol" => 1})
+    end
+  end
+
+  def add_concepts(*concept_hashes)
+    concepts = concept_hashes.map { |h| described_class::Concept.new(h) }
+    concepts.each { |c| instance.store c }
+  end
 end


### PR DESCRIPTION
* Implement clean & testable `Glossary#language_statistics` to replace ugly & unmaintainable calculations in Liquid.
* Expose `glossary` variable globally in Liquid templates.