### PR TITLE
Refactor page header and make it more configurable

### DIFF
--- a/_includes/page-header.html
+++ b/_includes/page-header.html
@@ -1,0 +1,31 @@
+{% assign title = page.title | default: page.title_html | default: layout.title | default: layout.title_html %}
+{% assign parent_title = page.parent_title | default: layout.parent_title %}
+{% assign parent_link = page.parent_link | default: layout.parent_link %}
+{% if title or parent_title %}
+  <header>
+    {% if parent_title %}
+      <p class="section-title">
+        {% if parent_link %}
+          <a href="{{ parent_link }}">{{ parent_title }}</a>
+        {% else %}
+          {{ parent_title }}
+        {% endif %}
+      </p>
+    {% endif %}
+
+    {% if title %}
+      <h1>{{ title }}</h1>
+    {% endif %}
+
+    {% if page.date or page.version %}
+      <div class="meta">
+        {% if page.date %}
+          <p>{{ page.date | date: '%B %d, %Y' }}
+        {% endif %}
+        {% if page.version %}
+          <p>Version: {{ page.version }}
+        {% endif %}
+      </div>
+    {% endif %}
+  </header>
+{% endif %}

--- a/_includes/page-header.html
+++ b/_includes/page-header.html
@@ -17,7 +17,7 @@
       <h1>{{ title }}</h1>
     {% endif %}
 
-    {% if page.date or page.version %}
+    {% if page.show_header_meta and page.date or page.version %}
       <div class="meta">
         {% if page.date %}
           <p>{{ page.date | date: '%B %d, %Y' }}

--- a/_layouts/base-page.html
+++ b/_layouts/base-page.html
@@ -2,36 +2,6 @@
 # “Normal” page with header.
 layout: default
 ---
-{% assign title = page.title | default: page.title_html | default: layout.title | default: layout.title_html %}
-{% assign parent_title = page.parent_title | default: layout.parent_title %}
-{% assign parent_link = page.parent_link | default: layout.parent_link %}
-{% if title or parent_title %}
-  <header>
-    {% if parent_title %}
-      <p class="section-title">
-        {% if parent_link %}
-          <a href="{{ parent_link }}">{{ parent_title }}</a>
-        {% else %}
-          {{ parent_title }}
-        {% endif %}
-      </p>
-    {% endif %}
-
-    {% if title %}
-      <h1>{{ title }}</h1>
-    {% endif %}
-
-    {% if page.date or page.version %}
-      <div class="meta">
-        {% if page.date %}
-          <p>{{ page.date | date: '%B %d, %Y' }}
-        {% endif %}
-        {% if page.version %}
-          <p>Version: {{ page.version }}
-        {% endif %}
-      </div>
-    {% endif %}
-  </header>
-{% endif %}
+{% include page-header.html %}
 
 {{ content }}

--- a/_layouts/base-page.html
+++ b/_layouts/base-page.html
@@ -27,7 +27,7 @@ layout: default
           <p>{{ page.date | date: '%B %d, %Y' }}
         {% endif %}
         {% if page.version %}
-          <p>Versoin: {{ page.version }}
+          <p>Version: {{ page.version }}
         {% endif %}
       </div>
     {% endif %}


### PR DESCRIPTION
* Extract page header to partial template.
* Allow enabling and disabling the subtitle with template variables.
* As a side effect, it fixes some issues with migration to Jekyll 4, because `page.date` variable is more widely available in Jekyll 4, and the old logic needed updating anyway.