### PR TITLE
Description and tagline

### DIFF
--- a/_includes/_title.html
+++ b/_includes/_title.html
@@ -2,4 +2,4 @@
 {% elsif page.title %}{{ page.title | escape }} —
 {% else %}{{ site.title | escape }} —
 {% endif %}
-{{ site.description }}
+{{ site.tagline }}

--- a/_includes/_title.html
+++ b/_includes/_title.html
@@ -2,4 +2,4 @@
 {% elsif page.title %}{{ page.title | escape }} —
 {% else %}{{ site.title | escape }} —
 {% endif %}
-{{ site.tagline }}
+{{ site.tagline | escape }}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,6 +2,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="{{ site.description }}">
 
   <title>{% include _title.html %}</title>
 


### PR DESCRIPTION
Tagline is something meant to be included in `<title>`, whereas description is meant for `<meta name="description">`.

Fixes #86.