### PR TITLE
Suggest crawlers not to index our staging sites

### DIFF
--- a/_pages/robots.txt
+++ b/_pages/robots.txt
@@ -1,0 +1,11 @@
+---
+layout: null
+permalink: "/robots.txt"
+---
+{%- if jekyll.environment == "production" -%}
+User-agent: *
+Sitemap: {{ "sitemap.xml" | absolute_url }}
+{%- else -%}
+User-agent: *
+Disallow: /
+{%- endif %}


### PR DESCRIPTION
Although Jekyll-Sitemap provides `robots.txt` already, we need a custom one in order to suggest crawlers not to index our staging sites.