### PR TITLE
Extract concepts list from concepts.adoc template

### DIFF
--- a/_includes/concepts-list.html
+++ b/_includes/concepts-list.html
@@ -1,0 +1,23 @@
+<div class="all-concepts">
+  <table>
+    <thead>
+      <tr>
+        <th class="field-termid">Term ID
+        <th class="field-term">Term
+      </tr>
+    </thead>
+
+    <tbody>
+      {% for concept in include.concepts %}
+        <tr>
+          <td class="field-termid">
+            <a href="{{ concept.url | relative_url }}">{{ concept.termid }}</a>
+          </td>
+          <td class="field-term">
+            <a href="{{ concept.url | relative_url }}">{{ concept.term }}</a>
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>

--- a/_pages/concepts.adoc
+++ b/_pages/concepts.adoc
@@ -9,8 +9,8 @@ title: All Concepts
 
 The concepts below are sorted by term name, alphabetically, in a case-insensitive way.
 
-++++
-{% assign sorted_concepts = site.concepts | sort_natural: "term" %}
+{% assign sorted_concepts = site.concepts | sort_natural: "term" -%}
 
+++++
 {% include concepts-list.html concepts=sorted_concepts %}
 ++++

--- a/_pages/concepts.adoc
+++ b/_pages/concepts.adoc
@@ -10,7 +10,7 @@ title: All Concepts
 The concepts below are sorted by term name, alphabetically, in a case-insensitive way.
 
 ++++
-{% assign sortedConcepts = site.concepts | sort_natural: "term" %}
+{% assign sorted_concepts = site.concepts | sort_natural: "term" %}
 
-{% include concepts-list.html concepts=sortedConcepts %}
+{% include concepts-list.html concepts=sorted_concepts %}
 ++++

--- a/_pages/concepts.adoc
+++ b/_pages/concepts.adoc
@@ -12,27 +12,5 @@ The concepts below are sorted by term name, alphabetically, in a case-insensitiv
 ++++
 {% assign sortedConcepts = site.concepts | sort_natural: "term" %}
 
-<div class="all-concepts">
-  <table>
-    <thead>
-      <tr>
-        <th class="field-termid">Term ID
-        <th class="field-term">Term
-      </tr>
-    </thead>
-
-    <tbody>
-      {% for concept in sortedConcepts %}
-        <tr>
-          <td class="field-termid">
-            <a href="{{ concept.url | relative_url }}">{{ concept.termid }}</a>
-          </td>
-          <td class="field-term">
-            <a href="{{ concept.url | relative_url }}">{{ concept.term }}</a>
-          </td>
-        </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-</div>
+{% include concepts-list.html concepts=sortedConcepts %}
 ++++


### PR DESCRIPTION
Embedding a large piece of HTML within an AsciiDoc template is a poor idea.  Also, this list is potentially re-usable, what has been proven in IEV site.