### PR TITLE
Remove trailing new line in <title> tag

### DIFF
--- a/_includes/title.html
+++ b/_includes/title.html
@@ -1,2 +1,2 @@
 {% assign title = page.term | default: page.title | default: site.title -%}
-{{ title | escape }} — {{ site.tagline | escape }}
+{{ title | escape }} — {{ site.tagline | escape -}}


### PR DESCRIPTION
Improve white characters control in title.html partial template in order to remove an excessive new line, which looks ugly in diffs.