### PR TITLE
Hide navbar on small screens

### DIFF
--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -354,6 +354,10 @@ body {
         margin-right: 0;
       }
 
+      @media screen and (max-width: $bigscreenBreakpoint) {
+        display: none;
+      }
+
       li {
         display: inline;
         margin-right: 1em;


### PR DESCRIPTION
As discussed in https://github.com/geolexica/isotc211.geolexica.org/issues/18.

Other pages are still accessible via hamburger menu.