### PR TITLE
Fix CSS at screen size breakpoints

### DIFF
--- a/_sass/concept.scss
+++ b/_sass/concept.scss
@@ -108,7 +108,7 @@ body.concept {
     padding-top: 1em;
     padding-bottom: 1em;
 
-    @media screen and (max-width: $bigscreenBreakpoint) {
+    @media screen and (max-width: $bigscreenBreakpoint - 1) {
       &.field {
         display: block;
       }

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -250,7 +250,7 @@ body {
 
             box-sizing: border-box;
 
-            @media screen and (max-width: $bigscreenBreakpoint) {
+            @media screen and (max-width: $bigscreenBreakpoint - 1) {
               margin-right: -1px;
               margin-bottom: -1px;
               flex: 1;
@@ -272,7 +272,7 @@ body {
             flex-flow: row wrap;
 
             .widget-item {
-              @media screen and (max-width: $bigscreenBreakpoint) {
+              @media screen and (max-width: $bigscreenBreakpoint - 1) {
                 flex-basis: 50%;
                 &.home {
                   flex: 0;
@@ -320,7 +320,7 @@ body {
         }
       }
 
-      @media screen and (max-width: $bigscreenBreakpoint) {
+      @media screen and (max-width: $bigscreenBreakpoint - 1) {
         .parent-org-reference .logo-link img {
           visibility: hidden;
         }
@@ -354,7 +354,7 @@ body {
         margin-right: 0;
       }
 
-      @media screen and (max-width: $bigscreenBreakpoint) {
+      @media screen and (max-width: $bigscreenBreakpoint - 1) {
         display: none;
       }
 


### PR DESCRIPTION
Styles for small and big screens used to be incorrectly applied together in case when screen width was equal to 900 pixels (breakpoint between small and big screens). Fixes #107.