### PR TITLE
Allow Jekyll 4.1

### DIFF
--- a/jekyll-geolexica.gemspec
+++ b/jekyll-geolexica.gemspec
@@ -35,7 +35,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "jekyll", ">= 3.8.5", "< 4.1"
+  # Jekyll 4.1.0 adds some breaking changes which are reverted in 4.1.1.
+  # I doubt we should be worried, but there is no good reason to allow them
+  # either.
+  # See: https://jekyllrb.com/news/2020/06/24/jekyll-4-1-1-released/
+  spec.add_runtime_dependency "jekyll", ">= 3.8.5", "< 4.2", "!= 4.1.0"
+
   spec.add_runtime_dependency "jekyll-asciidoc"
 
   spec.add_development_dependency "bundler", "~> 2.1"


### PR DESCRIPTION
Jekyll 4.1.x adds some non-breaking changes, with we may find useful.

Version 4.1.0 is slightly broken, that is why it is explicitly disallowed.

See: https://jekyllrb.com/news/2020/06/24/jekyll-4-1-1-released/