### PR TITLE
Ensure presence of Geolexica colletions

### DIFF
--- a/lib/jekyll/geolexica/concepts_generator.rb
+++ b/lib/jekyll/geolexica/concepts_generator.rb
@@ -22,6 +22,7 @@ module Jekyll
 
         make_pages
         sort_pages
+        initialize_collections
         group_pages_in_collections
       end
 
@@ -44,6 +45,17 @@ module Jekyll
 
       def sort_pages
         generated_pages.sort_by! { |p| p.termid.to_s }
+      end
+
+      def initialize_collections
+        %w[
+          concepts concepts_json concepts_jsonld
+          concepts_ttl concepts_tbx concepts_yaml
+        ].each do |label|
+          next if site.collections[label]
+          site.config["collections"][label] ||= { "output" => true }
+          site.collections[label] = Jekyll::Collection.new(site, label)
+        end
       end
 
       def group_pages_in_collections


### PR DESCRIPTION
Automatically instantiate `Jekyll::Collection` instances in case of site does not define them explicitly.  Since this change, the only thing required to enable given concept format is inclusion of its name in `geolexica.formats` array in `_config.yml`.

Fixes #69.