### PR TITLE
Fix turning off Liquid on certain pages

### DIFF
--- a/lib/jekyll/geolexica/concept_page.rb
+++ b/lib/jekyll/geolexica/concept_page.rb
@@ -26,7 +26,7 @@ module Jekyll
       def default_data
         {
           "layout" => layout,
-          "liquid" => uses_liquid,
+          "render_with_liquid" => uses_liquid,
           "permalink" => permalink,
           "representations" => concept.pages,
         }


### PR DESCRIPTION
Liquid can be disabled for given template via its front matter.  But the correct name of the responsible setting is `render_with_liquid`, not `liquid`, as it was done in #116.