### PR TITLE
Generalize search feature

### DIFF
--- a/_pages/concept-search-index.json
+++ b/_pages/concept-search-index.json
@@ -4,7 +4,7 @@ permalink: "/api/concept-search-index.json"
 [
   {% for concept in site.concepts %}
   {
-    "termid": {{ concept.termid }},
+    "termid": {{ concept.termid | jsonify }},
     "term": {{ concept.eng.terms.first.designation | jsonify }},
     "term_url": {{ concept.url | jsonify }},
     "sort_order": {

--- a/_pages/concept-search-index.json
+++ b/_pages/concept-search-index.json
@@ -1,5 +1,5 @@
 ---
-permalink: "/api/concepts-index-list.json"
+permalink: "/api/concept-search-index.json"
 ---
 [
   {% for concept in site.concepts %}

--- a/_pages/concepts-index-list.json
+++ b/_pages/concepts-index-list.json
@@ -6,6 +6,7 @@ permalink: "/api/concepts-index-list.json"
   {
     "termid": {{ concept.termid }},
     "term": {{ concept.eng.terms.first.designation | jsonify }},
+    "term_url": {{ concept.url | jsonify }},
 
     {% assign english_concept = concept["eng"] %}
     {% for lang in site.geolexica.term_languages %}
@@ -13,6 +14,7 @@ permalink: "/api/concepts-index-list.json"
     "{{ lang }}": {% if concept[lang] %}{
       "term": {{ concept[lang].terms.first.designation | jsonify }},
       "id": {{ concept[lang].id | jsonify }},
+      "term_url": {{ concept.url | append: "#entry-lang-" | append: lang | jsonify }},
       "entry_status": {{ english_concept.entry_status | jsonify }},
       "language_code": {{ concept[lang].language_code | jsonify }},
       "review_decision": {{ english_concept.review_decision | jsonify }}

--- a/_pages/concepts-index-list.json
+++ b/_pages/concepts-index-list.json
@@ -7,6 +7,9 @@ permalink: "/api/concepts-index-list.json"
     "termid": {{ concept.termid }},
     "term": {{ concept.eng.terms.first.designation | jsonify }},
     "term_url": {{ concept.url | jsonify }},
+    "sort_order": {
+      "natural": {{ forloop.index }}
+    },
 
     {% assign english_concept = concept["eng"] %}
     {% for lang in site.geolexica.term_languages %}

--- a/assets/js/concept-search-worker.js
+++ b/assets/js/concept-search-worker.js
@@ -2,7 +2,7 @@
 ---
 importScripts('/assets/js/babel-polyfill.js');
 
-const CONCEPTS_URL = '/api/concepts-index-list.json';
+const CONCEPTS_URL = '/api/concept-search-index.json';
 
 /** For example:
  *    const LANGUAGES = [ 'eng', 'deu' ];

--- a/assets/js/concept-search-worker.js
+++ b/assets/js/concept-search-worker.js
@@ -72,7 +72,7 @@ async function filterAndSort(params) {
       });
   }
 
-  return concepts.sort((item1, item2) => item1.termid - item2.termid);
+  return concepts.sort((item1, item2) => item1.sort_order.natural - item2.sort_order.natural);
 }
 
 onmessage = async function(msg) {

--- a/assets/js/concept-search-worker.js
+++ b/assets/js/concept-search-worker.js
@@ -1,21 +1,16 @@
+---
+---
 importScripts('/assets/js/babel-polyfill.js');
 
 const CONCEPTS_URL = '/api/concepts-index-list.json';
 
-const LANGUAGES = [
-  'eng',
-  'ara',
-  'spa',
-  'swe',
-  'kor',
-  'rus',
-  'ger',
-  'fre',
-  'fin',
-  'jpn',
-  'dan',
-  'chi',
-];
+/** For example:
+ *    const LANGUAGES = [ 'eng', 'deu' ];
+ *  Having a wrapper function helps not to break syntax highlight.
+ */
+const LANGUAGES = (function() {
+  return {{ site.geolexica.term_languages | jsonify }} || [];
+})();
 
 var concepts = null;
 var latestQuery = null;

--- a/assets/js/concept-search.js
+++ b/assets/js/concept-search.js
@@ -267,13 +267,7 @@
   ReactDOM.render(el(ConceptBrowser, null), document.querySelector('.browse-concepts'))
 
   function getConceptPermalink(concept) {
-    if (concept.termid) {
-      return `/concepts/${concept.termid}/`;
-    } else if (concept.id && concept.language_code) {
-      return `/concepts/${concept.id}/#entry-lang-${concept.language_code}`;
-    } else {
-      return null;
-    }
+    return concept.term_url;
   }
 
   function updateBodyClass({ searchQuery, expanded }) {

--- a/assets/js/concept-search.js
+++ b/assets/js/concept-search.js
@@ -18,6 +18,10 @@
     'chi',
   ];
 
+  const SEARCH_REFINEMENTS = [
+    'validity',
+  ];
+
 
   // React-based concept browser
   // ===========================
@@ -57,7 +61,7 @@
       this.stringInputRef = React.createRef();
 
       this.state = {
-        valid: 'valid',  // Required value of the entry_status field, or undefined
+        valid: SEARCH_REFINEMENTS.indexOf('validity') >= 0 ? 'valid' : undefined,  // Required value of the entry_status field, or undefined
         string: '',
       };
     }
@@ -75,10 +79,10 @@
           onChange: this.handleSearchStringChange}),
       ];
 
-      if (this.state.string.length > 1 && (this.props.refineControls || []).length > 0) {
+      if (this.state.string.length > 1 && (SEARCH_REFINEMENTS).length > 0) {
         var refineControls = [];
 
-        if (this.props.refineControls.indexOf('validity') >= 0) {
+        if (SEARCH_REFINEMENTS.indexOf('validity') >= 0) {
           refineControls.push(
             el('div', { key: 'validity', className: 'validity' }, [
               el('input', {
@@ -218,7 +222,7 @@
         el('div', { key: 'search-controls', className: 'search-controls' },
           el(SearchControls, {
             onSearchChange: this.handleSearchQuery,
-            refineControls: ['validity'],
+            refineControls: SEARCH_REFINEMENTS,
           })
         ),
       ];

--- a/assets/js/concept-search.js
+++ b/assets/js/concept-search.js
@@ -1,26 +1,24 @@
+---
+---
 (function () {
 
   const searchWorker = new Worker('/assets/js/concept-search-worker.js');
 
-  // TODO: Move to a shared module
-  const LANGUAGES = [
-    'eng',
-    'ara',
-    'spa',
-    'swe',
-    'kor',
-    'rus',
-    'ger',
-    'fre',
-    'fin',
-    'jpn',
-    'dan',
-    'chi',
-  ];
+  /** For example:
+   *    const LANGUAGES = [ 'eng', 'deu' ];
+   *  Having a wrapper function helps not to break syntax highlight.
+   */
+  const LANGUAGES = (function() {
+    return {{ site.geolexica.term_languages | jsonify }} || [];
+  })();
 
-  const SEARCH_REFINEMENTS = [
-    'validity',
-  ];
+  /** For example:
+   *    const SEARCH_REFINEMENTS = [ 'validity' ];
+   *  Having a wrapper function helps not to break syntax highlight.
+   */
+  const SEARCH_REFINEMENTS = (function() {
+    return {{ site.geolexica.search.refinements | jsonify }} || [];
+  })();
 
 
   // React-based concept browser

--- a/lib/jekyll/geolexica/concepts_generator.rb
+++ b/lib/jekyll/geolexica/concepts_generator.rb
@@ -44,7 +44,7 @@ module Jekyll
       end
 
       def sort_pages
-        generated_pages.sort_by! { |p| p.termid.to_s }
+        generated_pages.sort_by! { |p| p.termid }
       end
 
       def initialize_collections


### PR DESCRIPTION
This pull request makes the search front-end generic and configurable, so that scripts can be shared between sites. Till now, every site had its own copy of `concept-search.js` and `concept-search-worker.js` with some subtle changes. Obviously, it was a source of bugs and maintenance issues, some of which were mentioned in https://github.com/geolexica/geolexica-server/issues/106.

All the required differences, that is availability of particular search controls and supported languages, are now configurable. (Note that the latter shouldn't be needed at all, but it is due to some legacy code, probably written in hurry). Moreover, search index file was given a better name (`concept-search-index`), and enhanced a bit for the flexibility sake. A `sort_order` field has been added to the index, which in future may hold various sorting types.

CC @strogonoff, as you're probably interested in changes to this feature and you may have some comments.