### PR TITLE
Make search case-insensitive

### DIFF
--- a/assets/js/concept-search-worker.js
+++ b/assets/js/concept-search-worker.js
@@ -34,7 +34,7 @@ async function filterAndSort(params) {
       const matchingLanguages = LANGUAGES.
         filter((lang) => {
           const term = (item[lang] || {}).term;
-          return term && term.toLowerCase().indexOf(params.string) >= 0;
+          return term && term.toLowerCase().indexOf(queryString) >= 0;
         });
 
       if (matchingLanguages.length > 0) {


### PR DESCRIPTION
Convert query string to lower case before comparing it with designations. Fixes #124.