### PR TITLE
Handle multi-word search queries

### DIFF
--- a/assets/js/concept-search-worker.js
+++ b/assets/js/concept-search-worker.js
@@ -27,7 +27,7 @@ class SearchQuery {
 
   match(string) {
     const stringLC = string.toLowerCase();
-    return this.queryString.indexOf(stringLC) >= 0;
+    return stringLC.includes(this.queryString);
   }
 }
 

--- a/assets/js/concept-search-worker.js
+++ b/assets/js/concept-search-worker.js
@@ -15,6 +15,22 @@ const LANGUAGES = (function() {
 var concepts = null;
 var latestQuery = null;
 
+// TODO Support filters here maybe.
+class SearchQuery {
+  constructor(queryString) {
+    this.queryString = queryString.toLowerCase();
+  }
+
+  isEmpty() {
+    return this.queryString === "";
+  }
+
+  match(string) {
+    const stringLC = string.toLowerCase();
+    return this.queryString.indexOf(stringLC) >= 0;
+  }
+}
+
 function fetchConcepts() {
   if (concepts === null) {
     concepts = fetch(CONCEPTS_URL).then((resp) => resp.json());
@@ -25,16 +41,17 @@ function fetchConcepts() {
 async function filterAndSort(params) {
   var concepts = await fetchConcepts();
 
-  if (params.string !== '') {
+  const query = new SearchQuery(params.string);
+
+  if (!query.isEmpty()) {
     concepts = concepts.map((_item) => {
       // Search all localized term names for the presence of given search string
 
       const item = Object.assign({}, _item);
-      const queryString = params.string.toLowerCase();
       const matchingLanguages = LANGUAGES.
         filter((lang) => {
           const term = (item[lang] || {}).term;
-          return term && term.toLowerCase().indexOf(queryString) >= 0;
+          return term && query.match(term);
         });
 
       if (matchingLanguages.length > 0) {

--- a/assets/js/concept-search-worker.js
+++ b/assets/js/concept-search-worker.js
@@ -18,16 +18,16 @@ var latestQuery = null;
 // TODO Support filters here maybe.
 class SearchQuery {
   constructor(queryString) {
-    this.queryString = queryString.toLowerCase();
+    this.searchWords = queryString.toLowerCase().match(/\p{Letter}+/ug) || [];
   }
 
   isEmpty() {
-    return this.queryString === "";
+    return this.searchWords.length == 0;
   }
 
   match(string) {
     const stringLC = string.toLowerCase();
-    return stringLC.includes(this.queryString);
+    return this.searchWords.every((word) => stringLC.includes(word));
   }
 }
 


### PR DESCRIPTION
In search, match every word of the query separately.  This solves issues with reordered or missing words in a search query, which used to prevent terms from being matched. Fixes #131.

This pull request brings also some code-style improvements: SearchQuery class has been extracted to contain added logic, and `string.indexOf()` has been replaced with `string.includes()`.