### PR TITLE
Introduce Zeitwerk

### DIFF
--- a/jekyll-geolexica.gemspec
+++ b/jekyll-geolexica.gemspec
@@ -43,6 +43,9 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "jekyll-asciidoc"
 
+  # Zeitwerk::Loader#push_dir supports :namespace argument from v. 2.4.
+  spec.add_runtime_dependency "zeitwerk", "~> 2.4"
+
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", ">= 10"

--- a/lib/jekyll/geolexica.rb
+++ b/lib/jekyll/geolexica.rb
@@ -3,6 +3,15 @@
 
 require "jekyll"
 
+# Unfortunately, Zeitwerk::Loader.for_gem doesn't work well when gem's main
+# namespace is compound.
+require "zeitwerk"
+loader = Zeitwerk::Loader.new
+loader.tag = "jekyll-geolexica"
+loader.push_dir(File.join(__dir__, "geolexica"), namespace: Jekyll::Geolexica)
+loader.inflector = Zeitwerk::GemInflector.new(__FILE__)
+loader.setup
+
 module Jekyll
   module Geolexica
     # Loads Rake tasks which are provided in this gem.
@@ -19,13 +28,8 @@ module Jekyll
   end
 end
 
-require_relative "geolexica/configuration"
-require_relative "geolexica/concept_page"
-require_relative "geolexica/concept_serializer"
-require_relative "geolexica/concepts_generator"
-require_relative "geolexica/filters"
-require_relative "geolexica/glossary"
-require_relative "geolexica/hooks"
-require_relative "geolexica/meta_pages_generator"
+# Jekyll-Geolexica must be loaded eagerly because Jekyll has no other way
+# to learn about gem's features.
+loader.eager_load
 
 Jekyll::Geolexica::Hooks.register_all_hooks


### PR DESCRIPTION
[Zeitwerk](https://github.com/fxn/zeitwerk) is a modern code loader for Ruby. It will help us to avoid having series of clumsy `require` calls, which used to be a source of Git conflicts and errors (when forgot about mentioning a source file there).