### PR TITLE
Define gem namespace prior Zeitwerk setup

### DIFF
--- a/lib/jekyll/geolexica.rb
+++ b/lib/jekyll/geolexica.rb
@@ -3,15 +3,6 @@
 
 require "jekyll"
 
-# Unfortunately, Zeitwerk::Loader.for_gem doesn't work well when gem's main
-# namespace is compound.
-require "zeitwerk"
-loader = Zeitwerk::Loader.new
-loader.tag = "jekyll-geolexica"
-loader.push_dir(File.join(__dir__, "geolexica"), namespace: Jekyll::Geolexica)
-loader.inflector = Zeitwerk::GemInflector.new(__FILE__)
-loader.setup
-
 module Jekyll
   module Geolexica
     # Loads Rake tasks which are provided in this gem.
@@ -27,6 +18,16 @@ module Jekyll
     end
   end
 end
+
+# Unfortunately, Zeitwerk::Loader.for_gem doesn't work well when gem's main
+# namespace is compound.
+# Also, Jekyll::Geolexica must be defined prior passing it to #push_dir.
+require "zeitwerk"
+loader = Zeitwerk::Loader.new
+loader.tag = "jekyll-geolexica"
+loader.push_dir(File.join(__dir__, "geolexica"), namespace: Jekyll::Geolexica)
+loader.inflector = Zeitwerk::GemInflector.new(__FILE__)
+loader.setup
 
 # Jekyll-Geolexica must be loaded eagerly because Jekyll has no other way
 # to learn about gem's features.


### PR DESCRIPTION
In Zeitwerk setup, `Jekyll::Geolexica` module is passed as an method argument.  Hence, it must be defined before that.