### PR TITLE
using new glossarist format in other output types

### DIFF
--- a/_layouts/concept.jsonld.html
+++ b/_layouts/concept.jsonld.html
@@ -50,19 +50,15 @@ layout: null
     {%- if localized_term.definition -%}
     {
       "@language": "{{ site.data.lang[lang].iso-639-1 }}",
-      "@value": {{ localized_term.definition | jsonify }}
+      "@value": {{ localized_term.definition["content"] | jsonify }}
     }{% unless forloop.last %},{% endunless %}
     {%- endif -%}
     {%- endfor -%}
   ],
 
-  {%- if concept.date_accepted -%}
-  "dateAccepted": "{{ concept.date_accepted | date: "%F" }}",
-  {%- endif -%}
-
-  {%- if concept.date_amended -%}
-  "modified": "{{ concept.date_amended | date: "%F" }}",
-  {%- endif -%}
+  {%- for date in concept.dates -%}
+    "date{{ date.type | capitalize }}": "{{ date.date | date: "%F" }}",
+  {%- endfor -%}
 
   {%- if concept.notes -%}
   "notes": {
@@ -79,11 +75,11 @@ layout: null
         "note": {
           "@language": "{{ site.data.lang[lang].iso-639-1 }}",
           "@type": "skos:note",
-          {%- if lang != "eng" and note == concept.notes[forloop.index0] -%}
+          {% if lang != "eng" and note == concept.notes[forloop.index0] -%}
           "@value": "notTranslated",
-          {%- else -%}
-          "@value": {{ note | jsonify }}
-          {%- endif -%}
+          {% else -%}
+          "@value": {{ note["content"] | jsonify }}
+          {% endif -%}
         }
       }{% unless forloop.last %},{% endunless %}
       {%- endif -%}
@@ -94,7 +90,7 @@ layout: null
   },
   {%- endif -%}
 
-  {%- if concept.examples -%}
+  {% if concept.examples %}
   "examples": {
     {%- for lang in site.geolexica.term_languages -%}
     {%- assign localized_term = page[lang] -%}
@@ -112,7 +108,7 @@ layout: null
           {%- if lang != "eng" and example == concept.examples[forloop.index0] -%}
           "@value": "notTranslated",
           {%- else -%}
-          "@value": {{ example | jsonify }}
+          "@value": {{ example["content"] | jsonify }}
           {%- endif -%}
         }
       }{% unless forloop.last %},{% endunless %}
@@ -122,19 +118,19 @@ layout: null
     {%- endif -%}
     {%- endfor -%}
   },
-  {%- endif -%}
+  {% endif %}
 
   {%- assign authoritative_source = concept.sources | get_authoritative -%}
   {%- if authoritative_source -%}
-  "source": {
-  {%- if authoritative_source.link -%}
-    "link": "{{ authoritative_source.link }}",
-  {%- endif -%}
-  {%- if authoritative_source.clause -%}
-    "clause": "{{ authoritative_source.clause }}",
-  {%- endif -%}
-    "ref": "{{ authoritative_source.ref }}"
-  },
+    "source": {
+      {%- if authoritative_source.link -%}
+        "link": "{{ authoritative_source.link }}",
+      {%- endif -%}
+      {%- if authoritative_source.clause -%}
+        "clause": "{{ authoritative_source.clause }}",
+      {%- endif -%}
+        "ref": "{{ authoritative_source.ref }}"
+    },
   {%- endif -%}
 
   {%- if concept.entry_status -%}

--- a/_layouts/concept.ttl.html
+++ b/_layouts/concept.ttl.html
@@ -42,13 +42,15 @@ layout: null
 {%- endfor %}
   rdf-profile:termID <{{ page.url }}> ;
   rdfs:label "{{ english.terms.first.designation | escape }}" ;
-  skos:notation {{ page.termid }} ;
+  skos:notation "{{ page.termid }}" ;
 {%- for lang in site.geolexica.term_languages %}
-{%- assign localized_term = page[lang] -%}
-{%- if localized_term.definition %}
-  skos:definition "{{ localized_term.definition | escape }}"@{{ site.data.lang[lang].iso-639-1 }} ;
-{%- endif %}
-{%- endfor %}
+  {%- assign localized_term = page[lang] -%}
+  {%- if localized_term.definition %}
+  {% for definition in localized_term.definition -%}
+  skos:definition """{{ definition["content"] | escape }}"""@{{ site.data.lang[lang].iso-639-1 }} ;
+  {% endfor -%}
+  {%- endif %}
+{%- endfor -%}
   skos:inScheme rdf-profile:GeolexicaConceptScheme ;
 
 {%- for lang in site.geolexica.term_languages %}


### PR DESCRIPTION
using new glossarist format in `jsonld` and `ttl` files.

resolves #169 