### PR TITLE
darken inactive rows

### DIFF
--- a/_sass/mixins.scss
+++ b/_sass/mixins.scss
@@ -2,14 +2,21 @@
   width: 100%;
   font-size: 90%;
 
-  tr.main {
-    font-weight: bold;
+  tr {
+    &.main {
+      font-weight: bold;
 
-    td {
-      border-top: 2px solid #f0f0f0;
+      td {
+        border-top: 2px solid #f0f0f0;
+      }
+      &:first-child td {
+        border-top: 0;
+      }
     }
-    &:first-child td {
-      border-top: 0;
+
+    &.status-superseded {
+      opacity: 0.5;
+      background-color: darkgray;
     }
   }
 

--- a/assets/js/concept-search.js
+++ b/assets/js/concept-search.js
@@ -160,11 +160,12 @@
           return [item, ...localizedItems].map((item) => {
             const isLocalized = item.hasOwnProperty('language_code');
             const conceptId = isLocalized ? item.id : item.termid;
+            const supersededClass = item.hasOwnProperty('entry_status') && item.entry_status != 'valid' ? 'status-superseded' : ''
 
             return el(
               'tr', {
                 key: `${conceptId}-${item.language_code}`,
-                className: `${isLocalized ? 'localized' : 'main'}`,
+                className: `${isLocalized ? 'localized' : 'main'} ${supersededClass}`,
               },
               this.props.fields.map((field) => {
                 const view = field.view;


### PR DESCRIPTION
Superceded/retired terms should be highlighted in dark gray to indicate it is no longer active.

<img width="1440" alt="Screenshot 2022-07-27 at 6 16 26 PM" src="https://user-images.githubusercontent.com/5301572/181260038-7891d3da-6437-455a-a49c-eaa4ca9a0426.png">

closes #134 