### PR TITLE
Remove semicolon when there is a single source

### DIFF
--- a/_includes/localized-concept.html
+++ b/_includes/localized-concept.html
@@ -100,8 +100,8 @@
       {% if lang == "eng" %}
         [SOURCE:
           {% for source in english.sources %}
-            {{ source | display_authoritative_source }};
-          {% endfor %}
+            {{ source | display_authoritative_source }}{% unless forloop.last %};{% endunless %}
+          {%- endfor -%}
         ]
       {% else %}
         ORIGIN:  <a href="/registers/#language-{{ lang }}">{{ site.data.info.languages[lang].register-name }}</a>


### PR DESCRIPTION
Remove semicolon when there is a single source

<img width="1440" alt="Screenshot 2022-08-11 at 12 54 16 PM" src="https://user-images.githubusercontent.com/5301572/184088593-d4171541-8e18-4980-93e7-fdfeaefeaa5f.png">