### PR TITLE
Fix concept identifier for rdf format

### DIFF
--- a/_layouts/concept.ttl.html
+++ b/_layouts/concept.ttl.html
@@ -4,14 +4,16 @@ layout: null
 {%- assign concept = page["eng"] -%}
 {%- assign rdfprofile = "/api/rdf-profile" -%}
 {%- assign concept_html = page.representations.html -%}
-{%- assign concept_id = concept_html.url -%}
+{%- assign concept_id = concept_html.url | extract_concept_id -%}
 {%- assign english = page["eng"] -%}
-# baseURI: "{{ concept_id }}"
+{%- assign base_url = site.url | concepts_url -%}
+# baseURI: "{{ base_url }}"
 # imports: http://purl.org/dc/terms/
 # imports: https://www.geolexica.org/api/rdf-profile
 # imports: http://www.w3.org/2004/02/skos/core
 
-@prefix : <{{ concept_id }}> .
+@base <{{ base_url }}> .
+@prefix : <{{ base_url }}> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -20,13 +22,13 @@ layout: null
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<{{ concept_id }}>
+<{{ base_url }}>
   rdf:type owl:Ontology ;
   owl:imports dcterms: ;
   owl:imports <{{ rdfprofile }}> ;
   owl:imports <http://www.w3.org/2004/02/skos/core> ;
 .
-:closure
+<{{ concept_id }}>
   rdf:type skos:Concept ;
 
 {%- assign authoritative_source = concept.sources | get_authoritative -%}

--- a/lib/jekyll/geolexica/filters.rb
+++ b/lib/jekyll/geolexica/filters.rb
@@ -28,6 +28,22 @@ module Jekyll
         "#{source}, modified -- #{modification}"
       end
 
+      def concepts_url(base_url)
+        return if !base_url || base_url.empty?
+
+        if base_url.end_with?("/")
+          "#{base_url}concepts/"
+        else
+          "#{base_url}/concepts/"
+        end
+      end
+
+      def extract_concept_id(url)
+        return if !url || url.empty?
+
+        url.split("/").last
+      end
+
       REFERENCE_REGEX = /{{(urn:[^,}]*),?([^,}]*),?([^,}]*)?}}/.freeze
 
       def resolve_reference_to_links(text)

--- a/spec/unit/jekyll/geolexica/filters_spec.rb
+++ b/spec/unit/jekyll/geolexica/filters_spec.rb
@@ -76,6 +76,42 @@ RSpec.describe Jekyll::Geolexica::Filters do
     end
   end
 
+  describe "#concepts_url" do
+    subject { wrapper.method(:concepts_url) }
+
+    context "when base_url is nil or empty" do
+      it { expect(subject.call(nil)).to be_nil }
+      it { expect(subject.call("")).to be_nil }
+    end
+
+    context "when base_url ends with `/`" do
+      let(:base_url) { "https://test-url/" }
+
+      it { expect(subject.call(base_url)).to eq("#{base_url}concepts/") }
+    end
+
+    context "when base_url do not ends with `/`" do
+      let(:base_url) { "https://test-url" }
+
+      it { expect(subject.call(base_url)).to eq("#{base_url}/concepts/") }
+    end
+  end
+
+  describe "#extract_concept_id" do
+    subject { wrapper.method(:extract_concept_id) }
+
+    context "when url is nil or empty" do
+      it { expect(subject.call(nil)).to be_nil }
+      it { expect(subject.call("")).to be_nil }
+    end
+
+    context "when url contains id" do
+      let(:url) { "https://test-url/concepts/147" }
+
+      it { expect(subject.call(url)).to eq("147") }
+    end
+  end
+
   describe "#abbreviation?" do
     subject { wrapper.method(:abbreviation?) }
 


### PR DESCRIPTION
Fix concept identifier for rdf format

**Old Format**
```ttl
# baseURI: "/concepts/147/"
# imports: http://purl.org/dc/terms/
# imports: https://www.geolexica.org/api/rdf-profile
# imports: http://www.w3.org/2004/02/skos/core

@prefix : </concepts/147/> .
@prefix dcterms: <http://purl.org/dc/terms/> .
@prefix owl: <http://www.w3.org/2002/07/owl#> .
@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix rdf-profile: </api/rdf-profile#> .
@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .

</concepts/147/>
  rdf:type owl:Ontology ;
  owl:imports dcterms: ;
  owl:imports </api/rdf-profile> ;
  owl:imports <http://www.w3.org/2004/02/skos/core> ;
.
:closure
  rdf:type skos:Concept ;
  rdf-profile:engOrigin rdf-profile:English ;
  rdf-profile:termID </api/concepts/147.ttl> ;
  rdfs:label "geospatial metadata instance" ;
  skos:notation "147" ;
  skos:definition """single and specific metadata document, typically created in conformance with a metadata standard"""@en ;
  skos:inScheme rdf-profile:GeolexicaConceptScheme ;
  skos:prefLabel "geospatial metadata instance"@en ;
  :classification "preferred" ;
.
:linked-data-api
  rdf:type dcterms:MediaTypeOrExtent ;
  skos:prefLabel "linked-data-api" ;
.
```

**New format**
```ttl
# baseURI: "http://localhost:4000/concepts/"
# imports: http://purl.org/dc/terms/
# imports: https://www.geolexica.org/api/rdf-profile
# imports: http://www.w3.org/2004/02/skos/core

@base <http://localhost:4000/concepts/> .
@prefix : <http://localhost:4000/concepts/> .
@prefix dcterms: <http://purl.org/dc/terms/> .
@prefix owl: <http://www.w3.org/2002/07/owl#> .
@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix rdf-profile: </api/rdf-profile#> .
@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .

<http://localhost:4000/concepts/>
  rdf:type owl:Ontology ;
  owl:imports dcterms: ;
  owl:imports </api/rdf-profile> ;
  owl:imports <http://www.w3.org/2004/02/skos/core> ;
.
<147>
  rdf:type skos:Concept ;
  rdf-profile:engOrigin rdf-profile:English ;
  rdf-profile:termID </api/concepts/147.ttl> ;
  rdfs:label "geospatial metadata instance" ;
  skos:notation "147" ;
  skos:definition """single and specific metadata document, typically created in conformance with a metadata standard"""@en ;
  skos:inScheme rdf-profile:GeolexicaConceptScheme ;
  skos:prefLabel "geospatial metadata instance"@en ;
  :classification "preferred" ;
.
:linked-data-api
  rdf:type dcterms:MediaTypeOrExtent ;
  skos:prefLabel "linked-data-api" ;
.
```

**Turtle file output on [SKOS Play](http://labs.sparna.fr/skos-play/)**

![2022-08-18_14-04](https://user-images.githubusercontent.com/5301572/185356747-b8d13e89-0269-43a8-b40c-01b4235839e9.png)


closes #138 