### PR TITLE
Adding domain before definition

### DIFF
--- a/_includes/localized-concept.html
+++ b/_includes/localized-concept.html
@@ -41,7 +41,12 @@
 
     {% if localized_term.definition %}
       {% for definition in localized_term.definition %}
-        <p class="definition localized">{{ definition.content | escape | resolve_reference_to_links }}</p>
+        <p class="definition localized">
+          {%- if localized_term.domain != blank -%}
+            &lt;{{ localized_term.domain | escape }}&gt;&nbsp;
+          {%- endif -%}
+          {{ definition.content | escape | resolve_reference_to_links }}
+        </p>
       {% endfor %}
     {% else %}
       <p class="definition warning">Definition not provided in this language.</p>

--- a/lib/jekyll/geolexica/filters.rb
+++ b/lib/jekyll/geolexica/filters.rb
@@ -28,11 +28,6 @@ module Jekyll
         "#{source}, modified -- #{modification}"
       end
 
-      def debug(param)
-        require "pry"
-        binding.pry if param
-      end
-
       def concepts_url(base_url)
         return if !base_url || base_url.empty?
 

--- a/lib/jekyll/geolexica/filters.rb
+++ b/lib/jekyll/geolexica/filters.rb
@@ -28,6 +28,11 @@ module Jekyll
         "#{source}, modified -- #{modification}"
       end
 
+      def debug(param)
+        require "pry"
+        binding.pry if param
+      end
+
       def concepts_url(base_url)
         return if !base_url || base_url.empty?
 
@@ -44,7 +49,7 @@ module Jekyll
         url.split("/").last
       end
 
-      REFERENCE_REGEX = /{{(urn:[^,}]*),?([^,}]*),?([^,}]*)?}}/.freeze
+      REFERENCE_REGEX = /{{(urn:[^,}]*),?([^,}]*),?([^}]*)?}}/.freeze
 
       def resolve_reference_to_links(text)
         text.gsub(REFERENCE_REGEX) do |reference|


### PR DESCRIPTION
Adding domain before definition and enhancing regex to convert urn to links.

<img width="1680" alt="Screenshot 2022-08-24 at 2 15 17 PM" src="https://user-images.githubusercontent.com/5301572/186380320-cfeaf247-6ddb-4648-9869-4d79291a83d8.png">

resolves geolexica/isotc204-glossary#16